### PR TITLE
Add `--select` for deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ uv tool install --from git+https://github.com/dbt-labs/dbt-autofix.git dbt-autof
   - add `--dry-run` for running in dry run mode
   - add `--json` to get resulting data in a JSONL format
   - add `--json-schema-version v2.0.0-beta.4` to get the JSON schema from a specific Fusion release (by default we pick the latest)
+  - add `--select <path>` to only select files in a given path (by default the tool will look at all files of the dbt project)
 
 Each JSON object will have the following keys:
 

--- a/dbt_autofix/main.py
+++ b/dbt_autofix/main.py
@@ -34,7 +34,7 @@ def identify_duplicate_keys(
 
 
 @app.command(name="deprecations")
-def refactor_yml(
+def refactor_yml(  # noqa: PLR0913
     path: Annotated[Path, typer.Option("--path", "-p", help="The path to the dbt project")] = current_dir,
     dry_run: Annotated[bool, typer.Option("--dry-run", "-d", help="In dry run mode, do not apply changes")] = False,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output in JSON format")] = False,
@@ -44,10 +44,13 @@ def refactor_yml(
     json_schema_version: Annotated[
         Optional[str], typer.Option("--json-schema-version", help="Specific version of the JSON schema to use")
     ] = None,
+    select: Annotated[
+        Optional[List[str]], typer.Option("--select", "-s", help="Select specific paths to refactor")
+    ] = None,
 ):
     schema_specs = SchemaSpecs(json_schema_version)
 
-    changesets = changeset_all_sql_yml_files(path, schema_specs, dry_run, exclude_dbt_project_keys)
+    changesets = changeset_all_sql_yml_files(path, schema_specs, dry_run, exclude_dbt_project_keys, select)
     yaml_results, sql_results = changesets
     if dry_run:
         if not json_output:


### PR DESCRIPTION
Closes #43 - Allow people to select specific paths to refactor

Can be used with 
- one path: `dbt-autofix deprecations --select models/subfolder`
- or multiple ones : `dbt-autofix deprecations --select models/subfolder1 --select models/subfolder2`

The logic will check for each file of the project if it **contains** one of the `--select` paths