### PR TITLE
Add test and fix for `sort_keys`

### DIFF
--- a/dbt_autofix/refactor.py
+++ b/dbt_autofix/refactor.py
@@ -844,7 +844,7 @@ def changeset_remove_duplicate_keys(yml_str: str) -> YMLRuleRefactorResult:
 
         # we use dump from ruamel to keep indentation style but this loses quite a bit of formatting though
         # breakpoint()
-        refactored_yaml = DbtYAML().dump_to_string(yaml.safe_load(yml_str, sort_keys=False))  # type: ignore
+        refactored_yaml = DbtYAML().dump_to_string(yaml.safe_load(yml_str))  # type: ignore
     else:
         refactored_yaml = yml_str
 

--- a/tests/integration_tests/dbt_projects/project1/models/example/yml_with_dupes.yml
+++ b/tests/integration_tests/dbt_projects/project1/models/example/yml_with_dupes.yml
@@ -1,0 +1,6 @@
+models:
+  - name: my_dbt_model_with_dupes
+    description: desc1
+    description: desc2
+
+          

--- a/tests/integration_tests/dbt_projects/project1_expected/models/example/yml_with_dupes.yml
+++ b/tests/integration_tests/dbt_projects/project1_expected/models/example/yml_with_dupes.yml
@@ -1,0 +1,3 @@
+models:
+  - name: my_dbt_model_with_dupes
+    description: desc2


### PR DESCRIPTION
Issue reported in Slack with `sort_keys`.

Those are used only for `dump` in `pyyaml`.
Added an integration test but would benefit from unit test as well.