### PR TITLE
add --version/-v option support

### DIFF
--- a/dbt_autofix/main.py
+++ b/dbt_autofix/main.py
@@ -125,7 +125,7 @@ def print_fields_matrix(
 
 def version_callback(show_version: bool):
     if show_version:
-        typer.echo(f"dbt-autofix version: {version('dbt-autofix')}")
+        typer.echo(f"dbt-autofix {version('dbt-autofix')}")
         raise typer.Exit()
 
 


### PR DESCRIPTION
Resolves: https://github.com/dbt-labs/dbt-autofix/issues/135

```sh
(autofix) ➜  dbt-autofix git:(version-flag) dbt-autofix --version 
dbt-autofix 0.12.9.dev4+g9547c18
```

corresponding pypyproject.toml configs: 
* https://github.com/dbt-labs/dbt-autofix/blob/main/pyproject.toml#L17
* https://github.com/dbt-labs/dbt-autofix/blob/main/pyproject.toml#L37-L38

### Workaround

For older releases of dbt-autofix that utilized `uv` as the installation method (prior to https://github.com/dbt-labs/dbt-autofix/pull/139), this may work:

```
uv tool list | grep "dbt-autofix v"
```