### PR TITLE
Offer the pre-commit hook of `dbt-autofix deprecations`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: dbt-autofix
+  name: dbt-autofix
+  description: Automatically fix dbt deprecations
+  entry: |
+    bash -c 'for f in $@; do dbt-autofix deprecations --select "${f}"; done'
+  language: python
+  types: [yaml]
+  require_serial: true
+  additional_dependencies:
+    - "dbt-autofix"


### PR DESCRIPTION
## Motivation

If we develop a dbt project with many members together, it would be a little hassle to adjust the timing to change the schema YAML files for dbt 1.10. The code owner of a dbt project can execute dbt-autofix to change the whoe files. However, we need to change the ongoing code something like in GitHub pull requests. If a pre-commit hook to run `dbt-autofix deprecations` is offered, that would be convenient. 