### PR TITLE
Remove dangling word at end of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,3 @@ Running with `--behavior-changes` will run the _subset_ of fixes that would reso
 ### Using `AGENTS.md`
 
 [`AGENTS.md`](./AGENTS.md) is provided as a reference and starting place for those interested in using AI agents to assist them with migration work that dbt-autofix is not capable of resolving.
-
-The 


### PR DESCRIPTION
### Problem

There is a dangling "The" at the end of the README:

<img width="650" height="179" alt="image" src="https://github.com/user-attachments/assets/7eaa9a20-7c94-4e72-95bf-1be0bce55708" />

### Solution

Remove it.
