### PR TITLE
Add installation instructions for dbt Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ The following deprecations are covered by `dbt-autofix jobs`:
 
 ## Installation
 
+### In dbt Studio
+
+If you are using dbt Studio, no installation is needed. You can run `dbt-autofix` in the Studio command line just like you run other commands like `dbt build`.
+
 ### From PyPi
 
 #### With uv (recommended)


### PR DESCRIPTION
Hey friends! The deprecation warning CTA in Studio for upgrading to Fusion produces logs which point users to `dbt-autofix`, but the README doesn't reference Studio so I assumed at first that I needed to install it manually like other packages. So this PR adds a line about Studio so other noobs like me don't go off on a side quest trying to figure out how to use `uv` to install packages in Studio :) 