### PR TITLE
Reorder refactoring rules for --all CLI option

### DIFF
--- a/dbt_autofix/refactor.py
+++ b/dbt_autofix/refactor.py
@@ -90,7 +90,7 @@ def process_yaml_files_except_dbt_project(
         (changeset_refactor_yml_str, schema_specs),
         (changeset_owner_properties_yml_str, schema_specs),
     ]
-    all_rules = [*behavior_change_rules, *safe_change_rules]
+    all_rules = [*safe_change_rules, *behavior_change_rules]
     changesets = all_rules if all else behavior_change_rules if behavior_change else safe_change_rules
 
     ordered_changesets = [


### PR DESCRIPTION
This addresses a bug in https://github.com/dbt-labs/fs/issues/6466 where tabs in YAML files produce an error when using the --all option in the CLI:
```
/restricted-chroot/tmp/jobs/438952894/target/models/conformed/mart/web_analytics/schema.yml: 
ScannerError: while scanning for the next token found character '\t' that cannot start any token in 
"<unicode string>", line 74, column 22:
```
I believe this is occurring because the behavior change rules are applied first when `--all` is used, so they are failing on invalid YAML that would be fixed by the safe change rules.
The integration tests currently do not test the --all CLI option but I manually ran the CLI on the package where we saw this bug and it succeeded. I also tried changing the all option in the integration tests (see https://github.com/dbt-labs/dbt-autofix/pull/187) but the expected output didn't match, and I think updating those integration tests can go in a separate PR since the current tests are passing.