### PR TITLE
Pin GitHub Actions to specific SHAs (12 actions in 4 files)

### DIFF
--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -9,8 +9,8 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: mszostok/codeowners-validator@v0.7.2
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+      - uses: mszostok/codeowners-validator@f555ba682ec613249e7e478a4e0bff3ba35dc79f # mszostok/codeowners-validator@v0.7.2
         with:
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"
           checks: "duppatterns"

--- a/.github/workflows/nox-pr.yml
+++ b/.github/workflows/nox-pr.yml
@@ -8,8 +8,8 @@ jobs:
   nox:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - uses: fjwillemsen/setup-nox2@v3.0.0
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # astral-sh/setup-uv@v5
+      - uses: fjwillemsen/setup-nox2@fc5420448a3f1145b0128f86b1837e82841684a4 # fjwillemsen/setup-nox2@v3.0.0
       - run: nox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,22 +31,22 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # astral-sh/setup-uv@v3
 
       - name: Build artifacts
         run: uv build
 
       - name: Publish artifacts to PyPI Test
         if: inputs.deploy-to == 'PypiTest'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish artifacts to PyPI Prod
         if: inputs.deploy-to == 'PypiProd' || github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -8,8 +8,8 @@ jobs:
   nox:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - uses: fjwillemsen/setup-nox2@v3.0.0
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # astral-sh/setup-uv@v5
+      - uses: fjwillemsen/setup-nox2@fc5420448a3f1145b0128f86b1837e82841684a4 # fjwillemsen/setup-nox2@v3.0.0
       - run: nox --session check_latest_schema-3.13


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 4
- **Actions pinned**: 12

### 📝 Changes by file

#### `.github/workflows/release.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `astral-sh/setup-uv@v3` → `astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # astral-sh/setup-uv@v3`
- 📌 `pypa/gh-action-pypi-publish@release/v1` → `pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # pypa/gh-action-pypi-publish@release/v1`
- 📌 `pypa/gh-action-pypi-publish@release/v1` → `pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # pypa/gh-action-pypi-publish@release/v1`

#### `.github/workflows/nox-pr.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `astral-sh/setup-uv@v5` → `astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # astral-sh/setup-uv@v5`
- 📌 `fjwillemsen/setup-nox2@v3.0.0` → `fjwillemsen/setup-nox2@fc5420448a3f1145b0128f86b1837e82841684a4 # fjwillemsen/setup-nox2@v3.0.0`

#### `.github/workflows/schedule.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `astral-sh/setup-uv@v5` → `astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # astral-sh/setup-uv@v5`
- 📌 `fjwillemsen/setup-nox2@v3.0.0` → `fjwillemsen/setup-nox2@fc5420448a3f1145b0128f86b1837e82841684a4 # fjwillemsen/setup-nox2@v3.0.0`

#### `.github/workflows/codeowners-check.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `mszostok/codeowners-validator@v0.7.2` → `mszostok/codeowners-validator@f555ba682ec613249e7e478a4e0bff3ba35dc79f # mszostok/codeowners-validator@v0.7.2`

