### PR TITLE
docs: Add —-semantic-layer flag documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ uv tool install --from git+https://github.com/dbt-labs/dbt-autofix.git dbt-autof
   - add `--include-packages` to also autofix the packages installed. Just note that those fixes will be reverted at the next `dbt deps` and the long term fix will be to update the packages to versions compatible with Fusion.
   - add `--behavior-change` to run the _subset_ of fixes that would resolve deprecations that require a behavior change. Refer to the coverage tables above to determine which deprecations require behavior changes.
   - add `--all` to run all of the fixes possible - both fixes that potentially require behavior changes as well as not. Additionally, `--all` will apply fixes to as many files as possible, even if some files are unfixable (e.g. due to invalid yaml syntax).
+  - add `--semantic-layer` to migrate semantic models and metrics into your dbt models. This merges top-level semantic models with their corresponding dbt models and moves metrics into the model definitions. Note: This option cannot be used with `--include-packages`.
 
 Each JSON object will have the following keys:
 


### PR DESCRIPTION
closes #163

## Summary
This PR adds the missing documentation for the `--semantic-layer` flag in the README's usage section, as requested in #163.

## Changes
- Added documentation for `--semantic-layer` flag in the `deprecations` command options list
- Included a clear description of what the flag does (migrates semantic models and metrics into dbt model definitions)
- Noted the incompatibility with `--include-packages` option

## Motivation
The `--semantic-layer` flag was implemented and functional but not documented in the README, making it difficult for users to discover and use this feature.