### PR TITLE
[dependabot] configure to watch uv.lock + github actions

### DIFF
--- a/.github/workflows/uv-dependency-submission.yml
+++ b/.github/workflows/uv-dependency-submission.yml
@@ -1,0 +1,30 @@
+name: Dependency Submission for uv
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main', 'master']
+    paths:
+      - '**/uv.lock'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-submission:
+    name: Submit uv dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # needs to submit dependency graph data
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Submit dependency snapshot
+        uses: rmuir/uv-dependency-submission@1c48aaac13e566e39fd04269ff1900b86c1105c5 # v1.0.0

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Enable version updates for API
+  - package-ecosystem: "uv"
+    # Look for `pyproject.toml` and `uv.lock` file in the `root` directory
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot dependency graph does not natively support uv. This new workflow will submit dependencies to the dependency graph upon merge to default branch. For context, please see this thread: https://dbt-labs.slack.com/archives/C0159442M18/p1762786976919239