### PR TITLE
Handle quoted package names in dependencies

### DIFF
--- a/dbt_autofix/packages/dbt_package_text_file.py
+++ b/dbt_autofix/packages/dbt_package_text_file.py
@@ -61,6 +61,9 @@ class DbtPackageTextFileLine:
         if not pkg_match:
             return ""
         pkg = pkg_match.group("pkg")
+        if pkg is not None:
+            pkg = pkg.strip('"')
+            pkg = pkg.strip("'")
         return pkg
 
     def replace_version_string_in_line(self, new_string: str) -> bool:

--- a/tests/unit_tests/package_upgrades/test_dbt_package_text_file.py
+++ b/tests/unit_tests/package_upgrades/test_dbt_package_text_file.py
@@ -216,6 +216,7 @@ def test_match_version_in_line(input_str, expected_match):
         ("    package: dbt-labs/dbt_utils\n", "dbt-labs/dbt_utils"),
         ("    package: dbt-labs/dbt_utils  \n", "dbt-labs/dbt_utils"),
         ("    package: \"dbt-labs/dbt_utils\"  \n", "dbt-labs/dbt_utils"),
+        ("    package: \'dbt-labs/dbt_utils\'  \n", "dbt-labs/dbt_utils"),
     ],
 )
 def test_extract_package_in_line(input_str, expected_match):


### PR DESCRIPTION
Apparently package names can be quoted in dependencies, but autofix assumes they aren't when parsing the raw text file. This adds logic to strip the quotes so they can be accurately matched to the corresponding DbtPackage.