### PR TITLE
Update package owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @dbt-labs/dx
+* @chayac @dbt-labs/dbt-package-owners
 
 
 ### Deprecations


### PR DESCRIPTION
Adding myself as a codeowner so I can review PRs in repo, with dbt-package-owners as a backup. I'm also removing DX as a codeowner per Anders's request, although I will still tag DX as needed for user facing changes.