### PR TITLE
Fix missing value in package upgrade output

### DIFF
--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -71,9 +71,9 @@ class PackageVersionUpgradeResult:
         logs.append(current_version_compat)
         if self.upgraded and self.upgraded_version and self.upgraded_version_compatibility_state is not None:
             logs.append(f"Upgraded version is compatible: {self.upgraded_version_compatibility_state.value}")
-        elif self.compatible_version is not None:
+        elif self.compatible_version is not None and self.upgraded_version_compatibility_state is not None:
             logs.append(
-                f"Compatible version is available ({self.compatible_version}): {self.upgraded_version_compatibility_state}"
+                f"Compatible version is available ({self.compatible_version}): {self.upgraded_version_compatibility_state.value}"
             )
         return logs
 


### PR DESCRIPTION
`.value` is missing on the log output for the case where a user hasn't used the `--force-upgrade` option and there is a compatible version available that exceeds the version range in their config, so the enum itself is printed instead of the value.

Bad output:
```
Identifying packages with available upgrades in /Users/chaya/workplace/build-conformance-test-cases/transitive_dependencies_run_id_448126103

[19:53:02] Project contains both packages.yml and dependencies.yml, package dependencies will only be loaded from packages.yml   package_upgrade.py:139

DRY RUN - NOT APPLIED: Packages updated in /Users/chaya/workplace/build-conformance-test-cases/transitive_dependencies_run_id_448126103/packages.yml:
  package Datavault-UK/automate_dv unchanged
    Package is already compatible with Fusion
    Current version is compatible: Version has been verified by dbt as Fusion-compatible even though its declared require-dbt-version may not include 
2.0
  package dbt-labs/dbt_project_evaluator unchanged
    Public package has Fusion-compatible version that is outside the project's requested version range
    Current version is not compatible: Version has been verified by dbt as incompatible with Fusion
    Compatible version is available (1.1.1): PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_INCLUDES_2_0
```

Good output:
```
Identifying packages with available upgrades in /Users/chaya/workplace/build-conformance-test-cases/transitive_dependencies_run_id_448126103

[20:04:20] Project contains both packages.yml and dependencies.yml, package dependencies will only be loaded from packages.yml   package_upgrade.py:139

DRY RUN - NOT APPLIED: Packages updated in /Users/chaya/workplace/build-conformance-test-cases/transitive_dependencies_run_id_448126103/packages.yml:
  package Datavault-UK/automate_dv unchanged
    Package is already compatible with Fusion
    Current version is compatible: Version has been verified by dbt as Fusion-compatible even though its declared require-dbt-version may not include 
2.0
  package dbt-labs/dbt_project_evaluator unchanged
    Public package has Fusion-compatible version that is outside the project's requested version range
    Current version is not compatible: Version has been verified by dbt as incompatible with Fusion
    Compatible version is available (1.1.1): require-dbt-version includes version 2.0
```