### PR TITLE
Update CI to run on Python 3.13 until we can move to mashumaro compatible with 3.14

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -13,5 +13,5 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # astral-sh/setup-uv@v5
       - uses: fjwillemsen/setup-nox2@fc5420448a3f1145b0128f86b1837e82841684a4 # fjwillemsen/setup-nox2@v3.0.0
       - run: nox --session check_latest_schema-3.13
-      - run: uv sync --all-extras --all-packages 
-      - run: uv run pytest
+      - run: uv sync --all-extras --all-packages --python 3.13
+      - run: uv run --python 3.13 pytest


### PR DESCRIPTION
Today the CI job is failing every hour as it tries to run on Python 3.14 on a mashumaro version that is not compatible