### PR TITLE
Correct location of `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,16 @@
 version: 2
 updates:
   # Enable version updates for API
-  - package-ecosystem: "uv"
+  - package-ecosystem: uv
     # Look for `pyproject.toml` and `uv.lock` file in the `root` directory
-    directory: "/"
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
 
   # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: github-actions
     # Workflow files stored in the default location of `.github/workflows`
     # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
-    directory: "/"
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly


### PR DESCRIPTION
## Description

The path to `dependabot.yml` should be `.github/dependabot.yml`.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [ ] Ran `uv tool ruff format --config pyproject.toml` 
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [ ] Tests passed when run locally
