### PR TITLE
Carry explicit false join_to_timespine values through

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_schema_yml_semantic_layer.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_schema_yml_semantic_layer.py
@@ -573,7 +573,7 @@ def get_or_create_metric_for_measure(
 
     if fill_nulls_with is not None:
         artificial_metric["fill_nulls_with"] = fill_nulls_with
-    if join_to_timespine:
+    if join_to_timespine is not None:
         artificial_metric["join_to_timespine"] = join_to_timespine
 
     semantic_definitions.record_artificial_metric(

--- a/tests/integration_tests/dbt_projects/project_semantic_layer_expected/models/order_items.yml
+++ b/tests/integration_tests/dbt_projects/project_semantic_layer_expected/models/order_items.yml
@@ -141,6 +141,7 @@ models:
         type: simple
         hidden: true
         fill_nulls_with: -12
+        join_to_timespine: false
       - name: conversion_metric
         description: The conversion metric description
         type: conversion


### PR DESCRIPTION
## Description

Please describe the changes made and why they were made. Link to any relevant issues or tickets.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

I'm calling this a bug fix, but it's really just a tiny amount of polish.  Auto-fixing a measure into a metric would swallow explicit join_to_timespine values when they were false - this is functionally fine because that's the default value, but in practice, folks who defined the value explicitly despite it being the default probably want to keep that there for clarity/readability.

Reported internally [here](https://dbt-labs.slack.com/archives/C09Q3QUALUF/p1767994922857579).

## Checklist

*   [x] Ran `uv tool run ruff format --config pyproject.toml` 
*   [x] If this is a bug fix:
    *   [x] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   ]x] Added unit tests if needed
*   [x] Updated unit tests if needed
*   [x] Tests passed when run locally
