### PR TITLE
Add newline between file and first tline in test failure message

### DIFF
--- a/tests/integration_tests/test_full_dbt_projects.py
+++ b/tests/integration_tests/test_full_dbt_projects.py
@@ -65,9 +65,7 @@ def compare_dirs(dir1, dir2):
                 real_diffs = True
                 diff_message += f"\n{file}:\n"
                 diff_message += "".join(
-                    difflib.unified_diff(
-                        actual, expected, fromfile=f"actual/{file}", tofile=f"expected/{file}", lineterm=""
-                    )
+                    difflib.unified_diff(actual, expected, fromfile=f"actual/{file}", tofile=f"expected/{file}")
                 )
         if real_diffs:
             pytest.fail(diff_message)


### PR DESCRIPTION
## Description

Please describe the changes made and why they were made. Link to any relevant issues or tickets.

## Type of change

None of the below types are correct; this is just an improvement for contributors that improves the output of tests.

While I was working on #280 , I found that the output was missing some standard newlines and it was making it much harder to read.  The following images show what this looks like before and after my change:

Before:
<img width="792" height="231" alt="Screenshot 2026-01-13 at 5 06 04 PM" src="https://github.com/user-attachments/assets/6b5f193e-0d1b-40a5-97a6-8ce9e7a9bc60" />



After: 
<img width="559" height="282" alt="Screenshot 2026-01-13 at 5 05 38 PM" src="https://github.com/user-attachments/assets/9987c444-c618-498b-97ac-66f64cb5118a" />



*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv tool run ruff format --config pyproject.toml` 
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
