### PR TITLE
Update dev install instructions to use uv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,12 @@
 
 ## Installation
 
-To install `dbt-autofix` locally, simply run `pip install .` in a local python virtual environment. 
+This project uses `uv` for workspace and virutalenv management.
+
+1. Clone the repo: `gh repo clone dbt-labs/dbt-autofix`
+2. Install `uv`: [See docs](https://docs.astral.sh/uv/getting-started/installation/)
+3. Install dependencies: `uv sync --extra test`
+4. Activate virtual environment: `source .venv/bin/activate`
 
 You confirm your installation worked as expected via `dbt-autofix --version`
 


### PR DESCRIPTION
## What changed
Updated contributing documentation to use `uv` for virtual environment setup.

## Why
This project uses uv workspaces, so I'm thinking we should expect developers to use it in dev.



## Type of change

*   Bug fix (non-breaking change which fixes an issue)
*   New feature (non-breaking change which adds functionality)
*   Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [x] Documentation update

## Checklist

*   [x] Ran `uv tool run ruff format --config pyproject.toml` 
*   If this is a bug fix:
    *   Updated integration tests with bug repro
    *   Linked to bug report ticket
*   Added unit tests if needed
*   Updated unit tests if needed
*   [x] Tests passed when run locally
