### PR TITLE
Add test that measure.config.meta is copied over to created metrics

### DIFF
--- a/tests/integration_tests/dbt_projects/project_semantic_layer/models/order_items.yml
+++ b/tests/integration_tests/dbt_projects/project_semantic_layer/models/order_items.yml
@@ -43,6 +43,9 @@ semantic_models:
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
         expr: product_price
+        config:
+          meta:
+            label_in_meta: text in meta
       - name: revenue_measure_with_filter
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum

--- a/tests/integration_tests/dbt_projects/project_semantic_layer_expected/models/order_items.yml
+++ b/tests/integration_tests/dbt_projects/project_semantic_layer_expected/models/order_items.yml
@@ -109,6 +109,9 @@ models:
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
         expr: product_price
+        config:
+          meta:
+            label_in_meta: text in meta
         type: simple
         hidden: true
       - name: cumulative_revenue
@@ -129,6 +132,9 @@ models:
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
         expr: product_price
+        config:
+          meta:
+            label_in_meta: text in meta
         type: simple
         hidden: true
         fill_nulls_with: 0
@@ -147,6 +153,9 @@ models:
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
         expr: product_price
+        config:
+          meta:
+            label_in_meta: text in meta
         type: simple
         hidden: true
         fill_nulls_with: test
@@ -178,6 +187,9 @@ models:
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
         expr: product_price
+        config:
+          meta:
+            label_in_meta: text in meta
         type: simple
         hidden: true
         join_to_timespine: true


### PR DESCRIPTION
## Description

[LINEAR TASK](https://linear.app/dbt-labs/issue/DI-4410/autofix-verify-we-merge-tags-and-meta-correctly)

**This PR does not modify functional code.  It just adds tests.**

We don't have test coverage that shows that we carry over supported config data from measures to the metrics we create from them.  This PR aims to improve that.

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

N/A - Improved test coverage

## Checklist

*   [x] Ran `uvx ruff@0.14.14 check . --config pyproject.toml`
*   [x] Ran `uvx ruff@0.14.14 format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [x] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
