### PR TITLE
Document deprecations 

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -372,7 +372,7 @@ flags:
 
 ### UnexpectedJinjaBlockDeprecation
 
-> **Fires for:** `sql`, `py`
+> **Fires for:** `sql`
 
 Orphaned or out-of-context Jinja block tags (e.g., a stray `{% endmacro %}` before the opening
 `{% macro %}`) are currently silently ignored. dbt-fusion will treat them as errors.
@@ -434,17 +434,24 @@ models:
         custom_config_key: value
 ````
 
-**Before (SQL / Python):**
+**Before (SQL):**
 
 ```sql
 {{ config(materialized='table', custom_config_key='value') }}
 ```
 
-**After (SQL / Python):**
+**After (SQL):**
 
 ```sql
 {{ config(materialized='table', meta={'custom_config_key': 'value'}) }}
 ```
+
+**Before / After (Python):**
+
+> [!NOTE] TODO
+> Python models use `dbt.config(...)` rather than Jinja `{{ config(...) }}`, so the
+> before/after example needs to be written separately. The autofix also does not cover
+> Python models for this deprecation.
 
 **Autofix covers:** Move any custom key into `meta:` within the config block in yaml and sql jinja
 **Autofix does not cover:** Moving custom keys into meta in python models


### PR DESCRIPTION
I'm not sure if we actually want this in the repo or not, but putting this together was super helpful to me in understanding dbt-core deprecations and what we support in dbt-autofix so far.

I basically cross-referenced our docs, dbt-core itself, and this repo to see what deprecations exist, what code changes are needed, and if dbt-autofix handles it or not.

I will use this as the basis for scoping out the remaining Python model support. 

The rendered doc with the outline visible is much easier to read than the diff view:
https://github.com/dbt-labs/dbt-autofix/blob/7f3d9684ad18ff8803e2ccc8e4a33398e0f0c7ea/docs/deprecations.md