### PR TITLE
Fix: precommit install fails due to shallow clone

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -216,8 +216,8 @@ def test_wheel_installation(session):
     and verifies that dbt-fusion-package-tools is an unpinned dependency.
     """
     version, tools_dep = _build_and_install_wheels(session)
-    assert "dev" in tools_dep, f"Dev build: dbt-fusion-package-tools version should include dev but got: {tools_dep}"
-    session.log(f"version={version}, dev build")
+    assert "==" not in tools_dep, f"Dev build: dbt-fusion-package-tools should be unpinned but got: {tools_dep}"
+    session.log(f"version={version}, dev build (unpinned dep)")
 
 
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"], venv_backend="uv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "httpx>=0.27.0",
     "jinja2>=3.1.3,<4", # matches dbt-core: https://github.com/dbt-labs/dbt-core/blob/d1334866b1541d3b91e3ca36adcfbdf6c6c41059/core/pyproject.toml#L35
     "dbt-extractor>=0.5.0,<=0.6",
-    "dbt-fusion-package-tools=={{ version }}",
+    "dbt-fusion-package-tools{% if distance == 0 %}=={{ base }}{% endif %}",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Proposed resolution for #337

### Problem

Our v0.20 release broke pre-commit hooks 😭. Kindly reported to us by @billwallis in https://github.com/dbt-labs/dbt-autofix/issues/337.

When pre-commit tries to build dbt-autofix, it resolves it's dbt-fusion-package-tools dependency to version 0.0.0.post1.dev0, which is not available on PyPi. You then get an error message like this trying to run pre-commit. 

```
ERROR: Could not find a version that satisfies the requirement dbt-fusion-package-tools==0.0.0.post1.dev0 (from dbt-autofix) (from versions: 0.17.3a2, 0.17.3, 0.17.4, 0.17.5a0, 0.17.5, 0.17.6a0, 0.17.6, 0.17.7a0, 0.17.7, 0.18.0, 0.18.1, 0.18.2, 0.18.3, 0.18.4a0, 0.18.4, 0.18.5a0, 0.18.5, 0.18.6a0, 0.18.6, 0.18.7a0, 0.18.7, 0.19.0a0, 0.19.0, 0.20.0a0, 0.20.0a1, 0.20.0)
```


### Background
Here are some surprising things I learned!
- In the wild, pre-commit
    - pulls down dbt-autofix with a shallow-clone (depth=1). Shallow clones contain no tags.
    - builds dbt-autofix (the wheel) locally instead of pulling from PyPi.
- Normally, version is stamped in by uv-dynamic-versioning based on a git tagging system.
    - When no git tags are available, we define a fallback in pyproject.toml of 0.0.0
      - Note: This resolves to 0.0.0.post1.dev0 instead of just our hardcoded 0.0.0 fallback, because the fallback `0.0.0` becomes the `base` jinja variable for uv-dynamic-versioning. Version is computed by appending "distance" information to the base.
-  uv-dynamic-versioning cannot see the "rev" fro the pre-commit yaml, so we can't use that to figure out what fusion-package-tools to isntall
- When we were using pdm_build.py, we were conditionally leaving dbt-fusion-package-tools unbounded, meaning pre-commit could successfully install from pypi

### Changes
- Add a test that runs pre-commit on top of a shallow clone of dbt-autofix, to reproduce the bug
- Revert back to behavior we had previously: Leave dbt-fusion-package-tools completely unbounded if there is no git tag.



## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uvx ruff@0.14.14 check . --config pyproject.toml`
*   [x] Ran `uvx ruff@0.14.14 format --config pyproject.toml`
*   [ ]  If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [x] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
