### PR TITLE
Always emit complete message for packages even in case of errors

### DIFF
--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -66,11 +66,11 @@ def upgrade_packages(
         deps_file: Optional[DbtPackageFile] = generate_package_dependencies(path)
         if not deps_file:
             error_console.print("[red]-- No package dependency config found --[/red]")
-            return
+            raise Exception()
 
         if len(deps_file.package_dependencies) == 0:
             error_console.print("[red]-- No package dependencies found --[/red]")
-            return
+            raise Exception()
 
         package_upgrades: list[PackageVersionUpgradeResult] = check_for_package_upgrades(deps_file)
 


### PR DESCRIPTION
## Description

Always emit the `{"mode": "complete"}` message when a package upgrade is complete, even if the upgrade fails.

After:
```
(dbt-autofix) chaya@Chaya-Carey dbt-autofix % uv run dbt-autofix packages --path /Users/chaya/ --json
Identifying packages with available upgrades in /Users/chaya

[14:14:59] No package YML files found                                                     dbt_package_file.py:46
-- Package upgrade failed, please check logs for details --
{"mode": "complete"}
```

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [ ] Tests passed when run locally
