### PR TITLE
Don't silently update duplicate {% %} after well formed Jinja expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following deprecations are covered by `dbt-autofix deprecations`:
 | `CustomKeyInConfigDeprecation`    | YAML, SQL, Python | Move custom configs in `config:` blocks to `meta` and update Python `config.get()` calls to access from `meta` |   Full  | No |
 | `DuplicateYAMLKeysDeprecation`    | YAML files        | Remove duplicate keys in YAML files, keeping the second one to keep the same behaviour           |   Full  | No |
 | `CustomTopLevelKeyDeprecation` | YAML files | Delete custom top-level key-value pairs in YAML files | Full | No |
-| `UnexpectedJinjaBlockDeprecation` | SQL files         | Remove extra `{% endmacro %}` and `{% endif %}` that don't have corresponding opening statements |   Full  | No |
+| `UnexpectedJinjaBlockDeprecation` | SQL files         | Remove extra `{% end* … %}` closers (e.g. `endmacro`, `endif`, `endfor`) with no matching opener. Duplicate `{%` before a block tag, or a spurious extra `%}` after a well-formed `{% end* … %}`, is reported as invalid Jinja (warnings) and **not** auto-edited; other SQL refactors for that file are skipped (skips matches inside `{# … #}`) |   Full  | No |
 | `MissingPlusPrefixDeprecation` | `dbt_project.yml` | Prefix all built-in configs for models/tests etc... with a `+`                                     | Partial (Does not yet prefix custom configs) | No |
 | `ConfigDataPathDeprecation`       | `dbt_project.yml` | Remove deprecated config for data path (now seed)                                                |   Full  | No |
 | `ConfigLogPathDeprecation`        | `dbt_project.yml` | Remove deprecated config for log path                                                            |   Full  | No |

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -119,7 +119,7 @@ _DUPLICATE_OPENER_KEYWORDS = "|".join(
     )
 )
 
-# `{%` ... `{%` ... (before a block keyword) in one go — O(n) per `re.sub`.
+# `{%` ... `{%` before a block keyword. One `finditer` pass over the string (e.g. from `_list_invalid_jinja_block_patterns`).
 _DUPLICATE_JINJA_BLOCK_OPENER = re.compile(
     rf"({_JINJA_BLOCK_OPENER})(?:\s*{_JINJA_BLOCK_OPENER})+(?=\s*(?:{_DUPLICATE_OPENER_KEYWORDS})\b)"
 )
@@ -152,6 +152,9 @@ _STRAY_DUPLICATE_BLOCK_CLOSER = re.compile(
 # `{# ... #}` as in remove_unmatched_endings (kept in sync for comment skipping)
 _JINJA_COMMENT_RE = re.compile(r"{#.*?#}", re.DOTALL)
 
+# Block `{%` ... `%}` (same pattern as the former in-function JINJA_TAG_PATTERN; module-level to avoid re-compiling per call).
+_JINJA_BLOCK_TAG_PATTERN = re.compile(r"{%-?\+?\s*((?s:.*?))\s*\+?-?%}", re.DOTALL)
+
 
 def _jinja_comment_regions(sql_content: str) -> List[Tuple[int, int]]:
     return [(m.start(), m.end()) for m in _JINJA_COMMENT_RE.finditer(sql_content)]
@@ -171,14 +174,16 @@ def _line_number_at(s: str, pos: int) -> int:
     return s.count("\n", 0, pos) + 1
 
 
-def _list_invalid_jinja_block_patterns(sql_content: str) -> list[str]:
+def _list_invalid_jinja_block_patterns(sql_content: str, comment_regions: List[Tuple[int, int]]) -> list[str]:
     """Detect duplicate `{%` openers and stray extra `%}` after a full `{% end* ... %}` (outside `{#` comments only).
 
-    Returns one human-readable message per issue, de-duplicated (order preserved) when the same
-    line produces identical text.
+    `comment_regions` is typically from a single `_jinja_comment_regions(sql_content)` so callers
+    do not re-scan for `{# ... #}` a second time.
+
+    Returns one human-readable message per match; de-duplication uses `dict.fromkeys` (order
+    preserved), merging only when the full message string is byte-for-byte identical.
     """
     issues: list[str] = []
-    comment_regions = _jinja_comment_regions(sql_content)
     for m in _DUPLICATE_JINJA_BLOCK_OPENER.finditer(sql_content):
         if not _range_overlaps_any_of(m.start(), m.end(), comment_regions):
             line = _line_number_at(sql_content, m.start())
@@ -214,7 +219,8 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
     - Malformed comments ({#% ... %}, {# ... %#}, {#% ... %#})
     """
     original_content = content.current_str
-    invalid_msgs = _list_invalid_jinja_block_patterns(original_content)
+    comment_regions = _jinja_comment_regions(original_content)
+    invalid_msgs = _list_invalid_jinja_block_patterns(original_content, comment_regions)
     if invalid_msgs:
         return SQLRuleRefactorResult(
             rule_name="remove_unmatched_endings",
@@ -226,19 +232,10 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
             skip_remaining_sql_rules=True,
         )
     sql_content = original_content
-    # Regex patterns for Jinja tag and comment matching
-    JINJA_TAG_PATTERN = re.compile(r"{%-?\+?\s*((?s:.*?))\s*\+?-?%}", re.DOTALL)
-    # Match proper comments {# ... #} (same as module-level _JINJA_COMMENT_RE)
-    JINJA_COMMENT_PATTERN = _JINJA_COMMENT_RE
     MACRO_START = re.compile(r"^macro\s+([^\s(]+)")  # Captures macro name
     IF_START = re.compile(r"^if[(\s]+.*")  # if blocks can also be {% if(...) %}
     MACRO_END = re.compile(r"^endmacro")
     IF_END = re.compile(r"^endif")
-
-    # First, identify all comment regions to skip them
-    comment_regions: List[Tuple[int, int]] = []
-    for comment_match in JINJA_COMMENT_PATTERN.finditer(sql_content):
-        comment_regions.append((comment_match.start(), comment_match.end()))
 
     def is_in_comment(pos: int) -> bool:
         """Check if a position is within a Jinja comment."""
@@ -298,7 +295,7 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
     clean_content = "".join(clean_content_chars)
 
     # Find all Jinja tags
-    for match in JINJA_TAG_PATTERN.finditer(clean_content):
+    for match in _JINJA_BLOCK_TAG_PATTERN.finditer(clean_content):
         tag_content = match.group(1)
         start_pos = match.start()
         end_pos = match.end()

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -73,8 +73,138 @@ def extract_config_macro(sql_content: str) -> Optional[str]:
     return None
 
 
+# Jinja2 block openers like {% ... %} or {%- ... %} or {%+ ... %}
+_JINJA_BLOCK_OPENER = r"\{%-?\+?"
+
+# Jinja2 + dbt block openers. Alternation is sorted (longer tokens first).
+_DUPLICATE_OPENER_KEYWORDS = "|".join(
+    sorted(
+        {
+            "autoescape",
+            "block",
+            "call",
+            "do",
+            "elif",
+            "else",
+            "embed",
+            "endautoescape",
+            "endblock",
+            "endcall",
+            "endembed",
+            "endfilter",
+            "endfor",
+            "endif",
+            "endmacro",
+            "endmaterialization",
+            "endraw",
+            "endset",
+            "endtrans",
+            "endwith",
+            "extends",
+            "filter",
+            "for",
+            "from",
+            "if",
+            "import",
+            "include",
+            "macro",
+            "materialization",
+            "raw",
+            "set",
+            "snapshot",
+            "test",
+            "with",
+        },
+        key=lambda w: (-len(w), w),
+    )
+)
+
+# `{%` ... `{%` ... (before a block keyword) in one go — O(n) per `re.sub`.
+_DUPLICATE_JINJA_BLOCK_OPENER = re.compile(
+    rf"({_JINJA_BLOCK_OPENER})(?:\s*{_JINJA_BLOCK_OPENER})+(?=\s*(?:{_DUPLICATE_OPENER_KEYWORDS})\b)"
+)
+
+# Jinja2 block closers: duplicate `%}` can appear after any of these. Longer names first.
+_STRAY_DUPLICATE_END_TAG_NAMES = sorted(
+    {
+        "endautoescape",
+        "endblock",
+        "endcall",
+        "endembed",
+        "endfilter",
+        "endfor",
+        "endif",
+        "endmacro",
+        "endmaterialization",
+        "endraw",
+        "endset",
+        "endtest",
+        "endtrans",
+        "endwith",
+    },
+    key=lambda t: (-len(t), t),
+)
+# Group 1: well-formed Jinja `{%` block closer; following `(?:%})+` are spurious closers
+_STRAY_DUPLICATE_BLOCK_CLOSER = re.compile(
+    r"(\{%-?\+?\s*(?:" + "|".join(_STRAY_DUPLICATE_END_TAG_NAMES) + r")\s*\+?-?%\})(?:\s*%\})+"
+)
+
+# `{# ... #}` as in remove_unmatched_endings (kept in sync for comment skipping)
+_JINJA_COMMENT_RE = re.compile(r"{#.*?#}", re.DOTALL)
+
+
+def _jinja_comment_regions(sql_content: str) -> List[Tuple[int, int]]:
+    return [(m.start(), m.end()) for m in _JINJA_COMMENT_RE.finditer(sql_content)]
+
+
+def _range_overlaps_any_of(start: int, end: int, regions: List[Tuple[int, int]]) -> bool:
+    """Half-open [start, end) overlaps a region (also half-open) if the intersection is non-empty."""
+    for a, b in regions:
+        if not (end <= a or start >= b):
+            return True
+    return False
+
+
+def _line_number_at(s: str, pos: int) -> int:
+    if pos <= 0:
+        return 1
+    return s.count("\n", 0, pos) + 1
+
+
+def _list_invalid_jinja_block_patterns(sql_content: str) -> list[str]:
+    """Detect duplicate `{%` openers and stray extra `%}` after a full `{% end* ... %}` (outside `{#` comments only).
+
+    Returns one human-readable message per issue, de-duplicated (order preserved) when the same
+    line produces identical text.
+    """
+    issues: list[str] = []
+    comment_regions = _jinja_comment_regions(sql_content)
+    for m in _DUPLICATE_JINJA_BLOCK_OPENER.finditer(sql_content):
+        if not _range_overlaps_any_of(m.start(), m.end(), comment_regions):
+            line = _line_number_at(sql_content, m.start())
+            issues.append(
+                f"Invalid Jinja: duplicate block openers (near line {line}). "
+                "Remove the extra Jinja block start before the macro, if, set, or other block, then re-run. "
+                "Further SQL refactors for this file are skipped."
+            )
+    for m in _STRAY_DUPLICATE_BLOCK_CLOSER.finditer(sql_content):
+        if not _range_overlaps_any_of(m.start(), m.end(), comment_regions):
+            line = _line_number_at(sql_content, m.end() - 1)
+            issues.append(
+                f"Invalid Jinja: spurious Jinja closers after a well-formed end block (near line {line}). "
+                "Remove the spurious % character(s) and closing brace at the end of that Jinja end tag. "
+                "Further SQL refactors for this file are skipped."
+            )
+    return list(dict.fromkeys(issues))
+
+
 def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
     """Remove unmatched {% endmacro %} and {% endif %} tags from SQL content.
+
+    If the file has invalid Jinja (duplicate `{%` before a block tag, or a spurious extra `%}`
+    right after a well-formed `{% end* ... %}`), report warnings and **do not** apply further SQL refactors
+    to this file (and do not auto-edit those patterns). Other fixes run only on valid Jinja
+    in that regard when this rule runs first and finds no such issues.
 
     Handles:
     - Multi-line tags
@@ -83,11 +213,23 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
     - Jinja comments ({# ... #})
     - Malformed comments ({#% ... %}, {# ... %#}, {#% ... %#})
     """
-    sql_content = content.current_str
+    original_content = content.current_str
+    invalid_msgs = _list_invalid_jinja_block_patterns(original_content)
+    if invalid_msgs:
+        return SQLRuleRefactorResult(
+            rule_name="remove_unmatched_endings",
+            refactored=False,
+            refactored_content=original_content,
+            original_content=original_content,
+            deprecation_refactors=[],
+            refactor_warnings=invalid_msgs,
+            skip_remaining_sql_rules=True,
+        )
+    sql_content = original_content
     # Regex patterns for Jinja tag and comment matching
     JINJA_TAG_PATTERN = re.compile(r"{%-?\+?\s*((?s:.*?))\s*\+?-?%}", re.DOTALL)
-    # Match proper comments {# ... #}
-    JINJA_COMMENT_PATTERN = re.compile(r"{#.*?#}", re.DOTALL)
+    # Match proper comments {# ... #} (same as module-level _JINJA_COMMENT_RE)
+    JINJA_COMMENT_PATTERN = _JINJA_COMMENT_RE
     MACRO_START = re.compile(r"^macro\s+([^\s(]+)")  # Captures macro name
     IF_START = re.compile(r"^if[(\s]+.*")  # if blocks can also be {% if(...) %}
     MACRO_END = re.compile(r"^endmacro")
@@ -225,9 +367,9 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
 
     return SQLRuleRefactorResult(
         rule_name="remove_unmatched_endings",
-        refactored=result != sql_content,
+        refactored=result != original_content,
         refactored_content=result,
-        original_content=sql_content,
+        original_content=original_content,
         deprecation_refactors=deprecation_refactors,
     )
 

--- a/src/dbt_autofix/refactors/results.py
+++ b/src/dbt_autofix/refactors/results.py
@@ -275,12 +275,17 @@ class SQLRefactorResult:
                 if refactor.refactor_warnings:
                     flattened_warnings.extend(refactor.refactor_warnings)
 
-            to_print = {
+            to_print: dict = {
                 "mode": "dry_run" if self.dry_run else "applied",
                 "file_path": str(self.file_path),
                 "refactors": flattened_refactors,
                 "warnings": flattened_warnings,
             }
+            if self._abort_remaining_sql_refactors:
+                to_print["remaining_sql_rules_skipped"] = True
+                stopped = next((r.rule_name for r in reversed(self.refactors) if r.skip_remaining_sql_rules), None)
+                if stopped is not None:
+                    to_print["sql_rules_stopped_after_rule"] = stopped
             print(json.dumps(to_print))
             return
 
@@ -301,6 +306,13 @@ class SQLRefactorResult:
                 console.print(f"  {refactor.rule_name}", style="yellow")
                 for warning in refactor.refactor_warnings:
                     console.print(f"    Warning: {warning}", style="red")
+        if self._abort_remaining_sql_refactors:
+            _stopped = next((r.rule_name for r in reversed(self.refactors) if r.skip_remaining_sql_rules), "unknown")
+            console.print(
+                f"  Note: further SQL refactors for this file were not run (stopped after {_stopped!r}). "
+                "Fix the issues above and re-run.",
+                style="yellow",
+            )
 
 
 @dataclass

--- a/src/dbt_autofix/refactors/results.py
+++ b/src/dbt_autofix/refactors/results.py
@@ -116,17 +116,20 @@ class SQLRuleRefactorResult:
     deprecation_refactors: list[DbtDeprecationRefactor]
     refactored_file_path: Optional[Path] = None
     refactor_warnings: list[str] = field(default_factory=list)
+    #: When True, process_sql_files must not run later SQL refactors (e.g. invalid Jinja; fix file first).
+    skip_remaining_sql_rules: bool = False
 
     @property
     def refactor_logs(self):
         return [refactor.log for refactor in self.deprecation_refactors]
 
     def to_dict(self) -> dict:
-        ret_dict = {
+        return {
             "rule_name": self.rule_name,
             "deprecation_refactors": [refactor.to_dict() for refactor in self.deprecation_refactors],
+            "refactor_warnings": list(self.refactor_warnings),
+            "skip_remaining_sql_rules": self.skip_remaining_sql_rules,
         }
-        return ret_dict
 
 
 @dataclass
@@ -224,12 +227,15 @@ class SQLRefactorResult:
     original_content: str
     refactors: list[SQLRuleRefactorResult]
     has_warnings: bool = False
+    _abort_remaining_sql_refactors: bool = field(default=False, init=False, repr=False, compare=False)
 
     @property
     def refactored(self) -> bool:
         return any(r.refactored for r in self.refactors) or (self.refactored_file_path != self.file_path)
 
     def apply_changeset(self, func: Callable, config: SQLRefactorConfig) -> None:
+        if self._abort_remaining_sql_refactors:
+            return
         content = SQLContent(
             original_str=self.original_content,
             current_str=self.refactored_content,
@@ -243,6 +249,8 @@ class SQLRefactorResult:
                 self.refactored_file_path = result.refactored_file_path
         if result.refactor_warnings:
             self.has_warnings = True
+        if result.skip_remaining_sql_rules:
+            self._abort_remaining_sql_refactors = True
 
     def update_sql_file(self) -> None:
         """Update the SQL file with the refactored content"""

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block/dbt_project.yml
@@ -1,0 +1,9 @@
+name: "project_unexpected_jinja_block"
+version: "1.0.0"
+config-version: 2
+profile: "default"
+model-paths: ["models"]
+macro-paths: ["macros"]
+# Avoid unrelated MissingGenericTestArgumentsPropertyDeprecation churn in this fixture
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block/macros/build_date_malformed.sql
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block/macros/build_date_malformed.sql
@@ -1,0 +1,6 @@
+{# Malformed duplicate opener + stray %}; reported as invalid Jinja (warnings), file not auto-edited. #}
+{% {% macro build_date_jago_cbas(start_date, end_date, base_table_ingestion_time_column, watermark=1) %}
+  {% set date_selector = "DATE(" ~ base_table_ingestion_time_column ~ ") >= 1" %}
+  {% set upper_date_selector = "2" %}
+  {{ return(date_selector ~ ' AND ' ~ upper_date_selector) }}
+{% endmacro %}%}

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block/models/dummy_model.sql
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block/models/dummy_model.sql
@@ -1,0 +1,2 @@
+-- Integration test: invalid Jinja in macros is reported there; this model is unchanged
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected.stdout
@@ -1,0 +1,14 @@
+[
+  {
+    "mode": "complete"
+  },
+  {
+    "file_path": "project_unexpected_jinja_block/macros/build_date_malformed.sql",
+    "mode": "applied",
+    "refactors": [],
+    "warnings": [
+      "Invalid Jinja: duplicate block openers (near line 2). Remove the extra Jinja block start before the macro, if, set, or other block, then re-run. Further SQL refactors for this file are skipped.",
+      "Invalid Jinja: spurious Jinja closers after a well-formed end block (near line 6). Remove the spurious % character(s) and closing brace at the end of that Jinja end tag. Further SQL refactors for this file are skipped."
+    ]
+  }
+]

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected.stdout
@@ -6,6 +6,8 @@
     "file_path": "project_unexpected_jinja_block/macros/build_date_malformed.sql",
     "mode": "applied",
     "refactors": [],
+    "remaining_sql_rules_skipped": true,
+    "sql_rules_stopped_after_rule": "remove_unmatched_endings",
     "warnings": [
       "Invalid Jinja: duplicate block openers (near line 2). Remove the extra Jinja block start before the macro, if, set, or other block, then re-run. Further SQL refactors for this file are skipped.",
       "Invalid Jinja: spurious Jinja closers after a well-formed end block (near line 6). Remove the spurious % character(s) and closing brace at the end of that Jinja end tag. Further SQL refactors for this file are skipped."

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected/dbt_project.yml
@@ -1,0 +1,9 @@
+name: "project_unexpected_jinja_block"
+version: "1.0.0"
+config-version: 2
+profile: "default"
+model-paths: ["models"]
+macro-paths: ["macros"]
+# Avoid unrelated MissingGenericTestArgumentsPropertyDeprecation churn in this fixture
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected/macros/build_date_malformed.sql
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected/macros/build_date_malformed.sql
@@ -1,0 +1,6 @@
+{# Malformed duplicate opener + stray %}; reported as invalid Jinja (warnings), file not auto-edited. #}
+{% {% macro build_date_jago_cbas(start_date, end_date, base_table_ingestion_time_column, watermark=1) %}
+  {% set date_selector = "DATE(" ~ base_table_ingestion_time_column ~ ") >= 1" %}
+  {% set upper_date_selector = "2" %}
+  {{ return(date_selector ~ ' AND ' ~ upper_date_selector) }}
+{% endmacro %}%}

--- a/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected/models/dummy_model.sql
+++ b/tests/integration_tests/dbt_projects/project_unexpected_jinja_block_expected/models/dummy_model.sql
@@ -1,0 +1,2 @@
+-- Integration test: invalid Jinja in macros is reported there; this model is unchanged
+select 1 as id

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -30,6 +30,7 @@ from dbt_autofix.refactors.results import (
     DbtProjectYMLRefactorConfig,
     SQLContent,
     SQLRefactorConfig,
+    SQLRuleRefactorResult,
     YMLContent,
     YMLRefactorConfig,
     YMLRuleRefactorResult,
@@ -76,6 +77,14 @@ def _sql(sql_str: str) -> SQLContent:
 
 def _sql_cfg(schema_specs: SchemaSpecs | None = None, node_type: str = "models") -> SQLRefactorConfig:
     return SQLRefactorConfig(schema_specs=schema_specs or MockSchemaSpecs(), node_type=node_type)
+
+
+def _remove_unmatched_apply_on_fixed(fixed: str) -> SQLRuleRefactorResult:
+    """Run remove_unmatched_endings when original and current SQL are already the fixed text (idempotency re-check)."""
+    return remove_unmatched_endings(
+        SQLContent(original_str=fixed, current_str=fixed, current_file_path=Path("model.sql")),
+        _sql_cfg(),
+    )
 
 
 @pytest.fixture
@@ -309,6 +318,277 @@ class TestUnmatchedEndingsRemoval:
         assert "{% macro my_macro() %}" in result.refactored_content
         assert "{% endmacro %}" in result.refactored_content
         assert len(result.deprecation_refactors) == 0
+
+    def test_matched_macro_with_duplicate_block_opener(self):
+        """Malformed `{% {% macro` is invalid: do not edit; warn and skip further SQL rules."""
+        sql_content = """
+        {% {% macro my_macro(x, y) %}
+          {% set a = 1 %}
+          {{ return(a) }}
+        {% endmacro %}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert "{% {% macro" in result.refactored_content
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert any("duplicate block openers" in w for w in result.refactor_warnings)
+        assert result.deprecation_refactors == []
+
+    def test_duplicate_block_opener_before_if(self):
+        sql_content = """
+        {% {% if true %}
+        select 1
+        {% endif %}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert any("duplicate block openers" in w for w in result.refactor_warnings)
+        assert result.deprecation_refactors == []
+
+    def test_duplicate_block_opener_inside_macro_body(self):
+        """Duplicate `{%` before `set` in the body is invalid: do not collapse."""
+        sql_content = """
+        {% macro my_macro() %}
+          {% {% set a = 1 %}
+          select {{ a }}
+        {% endmacro %}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert any("duplicate block openers" in w for w in result.refactor_warnings)
+        assert result.deprecation_refactors == []
+
+    def test_duplicate_block_opener_inside_if_body(self):
+        """Valid `{% if` then duplicate opener before `set` in the body is invalid Jinja for this tool."""
+        sql_content = """
+        {% if true %}
+          {% {% set a = 1 %}
+          select {{ a }}
+        {% endif %}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert any("duplicate block openers" in w for w in result.refactor_warnings)
+        assert result.deprecation_refactors == []
+
+    def test_trailing_closer_after_endmacro(self):
+        """Stray duplicate `%}` after a valid `{% endmacro %}` is invalid: report and do not edit."""
+        sql_content = """
+        {% macro m() %}
+        select 1
+        {% endmacro %}%}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert "{% endmacro %}%}" in result.refactored_content
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert any("spurious Jinja closers" in w for w in result.refactor_warnings)
+        assert result.deprecation_refactors == []
+
+    def test_trailing_closer_after_endif(self):
+        """Stray duplicate `%}` after a valid `{% endif %}` is invalid: report and do not edit."""
+        sql_content = """
+        {% if true %}
+        select 1
+        {% endif %}%}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert any("spurious Jinja closers" in w for w in result.refactor_warnings)
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert result.deprecation_refactors == []
+
+    def test_macro_with_duplicate_opener_and_trailing_closer(self):
+        """Multiple invalid patterns: one message per duplicate opener and one for stray closer."""
+        sql_content = """
+        {% {% macro m() %}
+        {% if true %}
+          {% {% set x = 1 %}
+        {% endif %}
+        {{ x }}
+        {% endmacro %}%}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+        assert len([w for w in result.refactor_warnings if "duplicate block openers" in w]) == 2
+        assert len([w for w in result.refactor_warnings if "spurious Jinja closers" in w]) == 1
+        assert result.deprecation_refactors == []
+
+    def test_duplicate_opener_and_trailing_closer_build_date_macro(self):
+        """Reproduce duplicate `{%` on the macro line and a stray `%}` after `{% endmacro %}`."""
+        sql_content = r"""
+        {% {% macro build_date_jago_cbas(start_date, end_date, base_table_ingestion_time_column, watermark=1) %}
+          {% set date_selector = "x" %}
+          {{ return(date_selector) }}
+        {% endmacro %}%}
+        """
+        result = remove_unmatched_endings(_sql(sql_content + "\n"), _sql_cfg())
+        assert result.refactored is False
+        assert "{% {% macro" in result.refactored_content
+        assert "{% endmacro %}%}" in result.refactored_content
+        assert any("duplicate block openers" in w for w in result.refactor_warnings)
+        assert any("spurious Jinja closers" in w for w in result.refactor_warnings)
+        assert result.deprecation_refactors == []
+
+    def test_duplicate_opener_unchanged_inside_jinja_comment(self):
+        """Do not touch `{% {{%` that only appears inside `{# ... #}`."""
+        sql_content = """
+        {# note: {% {% macro in comment is invalid but leave it #}
+        select 1
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored is False
+        assert "{% {% macro" in result.refactored_content
+        assert len(result.deprecation_refactors) == 0
+
+    def test_stray_closer_after_endfor(self):
+        sql_content = """
+        {% for x in [1] %}
+          select {{ x }}
+        {% endfor %}%}
+        """
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert any("spurious Jinja closers" in w for w in result.refactor_warnings)
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+
+    def test_duplicate_opener_dbt_test_block(self):
+        sql_content = '{% {% test not_null(column_name="id") %}\nSELECT 1\n{% endtest %}\n'
+        result = remove_unmatched_endings(_sql(sql_content), _sql_cfg())
+        assert result.refactored_content == sql_content
+        assert "{% {% test" in result.refactored_content
+        assert any("duplicate block openers" in w for w in result.refactor_warnings)
+        assert result.refactored is False
+        assert result.skip_remaining_sql_rules is True
+
+    def test_jinja_normalization_idempotent(self):
+        """Invalid Jinja stays unchanged; a second run reports the same warnings."""
+        bad = """
+        {% {% macro t() %}
+        select 1
+        {% endmacro %}%}
+        """
+        r1 = remove_unmatched_endings(_sql(bad), _sql_cfg())
+        r2 = _remove_unmatched_apply_on_fixed(r1.refactored_content)
+        assert r1.refactored is False
+        assert r2.refactored is False
+        assert r2.refactored_content == r1.refactored_content
+        assert r1.refactor_warnings == r2.refactor_warnings
+        assert r1.skip_remaining_sql_rules and r2.skip_remaining_sql_rules
+
+    def test_idempotency_stray_closer_only(self):
+        """Stray-`%}`: still invalid on second pass; same content and warnings."""
+        sql = """
+        {% macro m() %}
+        select 1
+        {% endmacro %}%}
+        """
+        r1 = remove_unmatched_endings(_sql(sql), _sql_cfg())
+        r2 = _remove_unmatched_apply_on_fixed(r1.refactored_content)
+        assert r1.refactored is False
+        assert r2.refactored is False
+        assert r1.refactored_content == r2.refactored_content
+        assert r1.refactor_warnings == r2.refactor_warnings
+
+    def test_idempotency_duplicate_opener_only(self):
+        """Duplicate-`{%` before macro: still invalid; second pass unchanged."""
+        sql = """
+        {% {% macro m() %}
+        select 1
+        {% endmacro %}
+        """
+        r1 = remove_unmatched_endings(_sql(sql), _sql_cfg())
+        r2 = _remove_unmatched_apply_on_fixed(r1.refactored_content)
+        assert r1.refactored is False
+        assert r2.refactored is False
+        assert r1.refactored_content == r2.refactored_content
+        assert r1.refactor_warnings == r2.refactor_warnings
+
+    def test_idempotency_after_unmatched_endmacro_removal(self):
+        """Unmatched-`endmacro` strip: fixed content is idempotent on re-run."""
+        sql = """
+        select 1
+        {% endmacro %}
+        """
+        r1 = remove_unmatched_endings(_sql(sql), _sql_cfg())
+        r2 = _remove_unmatched_apply_on_fixed(r1.refactored_content)
+        assert r1.refactored is True
+        assert r2.refactored is False
+        assert r1.refactored_content == r2.refactored_content
+        assert "Removed unmatched" in r1.deprecation_refactors[0].log
+        assert r2.deprecation_refactors == []
+
+    def test_idempotency_clean_matched_sql_twice(self):
+        """Well-formed macro + endif: no change; repeat pass still no change."""
+        sql = """
+        {% macro k() %}{% if true %} select 1 {% endif %}{% endmacro %}
+        """
+        r1 = remove_unmatched_endings(_sql(sql), _sql_cfg())
+        r2 = _remove_unmatched_apply_on_fixed(r1.refactored_content)
+        assert r1.refactored is False
+        assert r2.refactored is False
+        assert r1.refactored_content == r2.refactored_content
+        assert r1.deprecation_refactors == []
+        assert r2.deprecation_refactors == []
+
+    def test_idempotency_third_consecutive_apply(self):
+        """Third run matches first: invalid Jinja is never auto-fixed here."""
+        bad = """
+        {% {% macro t() %}
+        select 1
+        {% endmacro %}%}
+        """
+        r1 = remove_unmatched_endings(_sql(bad), _sql_cfg())
+        r2 = _remove_unmatched_apply_on_fixed(r1.refactored_content)
+        r3 = _remove_unmatched_apply_on_fixed(r2.refactored_content)
+        assert r1.refactored is False
+        assert r2.refactored is False
+        assert r3.refactored is False
+        assert r1.refactored_content == r2.refactored_content == r3.refactored_content
+        assert r1.refactor_warnings == r2.refactor_warnings == r3.refactor_warnings
+
+    def test_invalid_jinja_warnings_include_near_line(self):
+        r = remove_unmatched_endings(
+            _sql("{% {% macro t() %}\n{% endmacro %}\n"),
+            _sql_cfg(),
+        )
+        assert any("near line" in w for w in r.refactor_warnings)
+        assert "duplicate block openers" in r.refactor_warnings[0]
+        assert r.deprecation_refactors == []
+
+    def test_invalid_jinja_skips_following_sql_rules(self):
+        """When remove_unmatched_endings sets skip_remaining_sql_rules, later rules are not applied."""
+        sql = """{% {% if true %}
+{{ config(materialized="view") }}
+select 1
+{% endif %}
+"""
+        agg = SQLRefactorResult(
+            dry_run=True,
+            file_path=Path("m.sql"),
+            refactored_file_path=Path("m.sql"),
+            refactored_content=sql,
+            original_content=sql,
+            refactors=[],
+        )
+        agg.apply_changeset(remove_unmatched_endings, _sql_cfg())
+        agg.apply_changeset(refactor_custom_configs_to_meta_sql, _sql_cfg())
+        assert len(agg.refactors) == 1
+        assert agg.refactored_content == sql
+        assert agg.refactors[0].skip_remaining_sql_rules is True
+        assert agg.has_warnings
 
     def test_matched_if(self):
         sql_content = """


### PR DESCRIPTION
## Description

dbt-autofix no longer “fixes” clearly broken Jinja in SQL (duplicate {% before a block, or an extra %} right after a well-formed {% end* … %}). Those cases are treated as invalid Jinja: the tool emits warnings with line hints, leaves the file unchanged for those patterns, and does not run any later SQL refactors on that file (config → meta, improved config access, etc.) until the file is fixed.

Detection (only outside proper {# … #} comments, same as other Jinja handling):

- Duplicate block openers like {% {% macro … / {% {% if … / {% {% set …
- Spurious closers like {% endmacro %}%} (and the same idea for other supported end* tags)

### Pipeline

- remove_unmatched_endings runs first among the “safe” SQL rules; if it sets skip_remaining_sql_rules, SQLRefactorResult.apply_changeset stops and does not invoke following rules.
- Unmatched {% endmacro %} / {% endif %} removal and UnexpectedJinjaBlockDeprecation logging still apply only when the file does not hit the invalid-pattern path.

### Output

- Warnings list per issue; duplicate identical full messages are de-duplicated (order preserved).
- JSON per file: warnings, and when the pipeline short-circuits: remaining_sql_rules_skipped, sql_rules_stopped_after_rule (e.g. remove_unmatched_endings). Console adds one summary line that later SQL refactors were not run and which rule caused it.
- SQLRuleRefactorResult.to_dict() includes refactor_warnings and skip_remaining_sql_rules.

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [x] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
