### PR TITLE
fix: on_error is now a recognized Fusion config key, not moved to meta

### DIFF
--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -2674,8 +2674,8 @@ def test_config_regex(input_str, expected_match):
 class TestRefactorCustomConfigsToMetaSQL:
     """Tests for refactor_custom_configs_to_meta_sql function"""
 
-    def test_on_error_with_env_var_moved_to_meta(self, schema_specs: SchemaSpecs):
-        """Test that on_error config IS moved to meta even when env_var() is present (static analysis)"""
+    def test_on_error_not_moved_to_meta(self, schema_specs: SchemaSpecs):
+        """on_error is a recognized Fusion config key and should NOT be moved to meta"""
         sql_content = """{{
     config(
         materialized=env_var("DBT_MAT_TABLE"),
@@ -2688,23 +2688,10 @@ class TestRefactorCustomConfigsToMetaSQL:
 
 select 1 as id
 """
-        expected_content = """{{ config(
-    materialized=env_var("DBT_MAT_TABLE"), 
-    tags=["smartsheet", "phi_resourcing"], 
-    transient=true, 
-    on_schema_change="sync_all_columns", 
-    meta={'on_error': 'warn'}
-) }}
-
-select 1 as id
-"""
         result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
 
-        assert result.refactored
-        assert result.refactored_content == expected_content
-        assert len(result.deprecation_refactors) == 1
-        assert "on_error" in result.deprecation_refactors[0].log
-        assert "meta" in result.deprecation_refactors[0].log
+        assert not result.refactored
+        assert result.refactored_content == sql_content
 
     def test_multiple_custom_configs_with_jinja_moved_to_meta(self, schema_specs: SchemaSpecs):
         """Test that multiple custom configs ARE moved to meta even with Jinja (static analysis)"""


### PR DESCRIPTION
## Summary

- The hourly cron CI (`Run Nox every hour to check JSON schema parsing`) has been failing since ~May 4 because the Fusion YAML schema was updated to include `on_error` as a recognized model config key
- The test `test_on_error_with_env_var_moved_to_meta` assumed `on_error` was a custom config that should be moved to `meta`, but the live schema now recognizes it as valid — so the refactor correctly skips it
- This PR updates the test to assert the new correct behavior: `on_error` is **not** moved to meta

## Test plan

- [ ] Confirm `pytest tests/unit_tests/test_refactor.py::TestRefactorCustomConfigsToMetaSQL::test_on_error_not_moved_to_meta` passes
- [ ] Confirm hourly cron CI goes green after merge