### PR TITLE
Change adapter type in parse conformance

### DIFF
--- a/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/check_parse_conformance.py
+++ b/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/check_parse_conformance.py
@@ -315,12 +315,9 @@ def check_fusion_schema_compatibility(
                 "  target: dev\n"
                 "  outputs:\n"
                 "    dev:\n"
-                "      type: postgres\n"
-                "      host: localhost\n"
-                "      port: 5432\n"
-                "      user: postgres\n"
-                "      password: postgres\n"
-                "      dbname: postgres\n"
+                "      type: snowflake\n"
+                "      account: none\n"
+                "      database: none\n"
                 "      schema: public\n"
             )
 


### PR DESCRIPTION
## Description

Changes the adapter type used in dbt_fusion_package_tools for testing Fusion parse compatibility. As of v172, Fusion produces an error for unsupported adapters, which includes Postgres. This is just a dummy profile since parse doesn't actually use a DB, so I'm replacing Postgres with Snowflake.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [ ] Ran `uv run ruff check . --config pyproject.toml`
*   [ ] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [ ] Tests passed when run locally
