### PR TITLE
Add --exclude option to list-yaml-duplicates

### DIFF
--- a/src/dbt_autofix/duplicate_keys.py
+++ b/src/dbt_autofix/duplicate_keys.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import yaml
 import yamllint.config
@@ -33,12 +33,21 @@ class DuplicateFound:
 def find_duplicate_keys(
     root_dir: Path,
     dry_run: bool = False,
+    excluded_paths: Optional[List[str]] = None,
 ) -> Tuple[List[DuplicateFound], List[DuplicateFound]]:
     """Find duplicate keys in the project and packages."""
     project_duplicates: List[DuplicateFound] = []
     package_duplicates: List[DuplicateFound] = []
 
     yml_files = set(root_dir.glob("**/*.yml")).union(set(root_dir.glob("**/*.yaml")))
+
+    if excluded_paths:
+        excluded_paths = [(root_dir / p).resolve() for p in excluded_paths]
+        yml_files = {
+            f
+            for f in yml_files
+            if not any(f.resolve() == ep or f.resolve().is_relative_to(ep) for ep in excluded_paths)
+        }
     yml_files_target = set((root_dir / "target").glob("**/*.yml")).union(set((root_dir / "target").glob("**/*.yaml")))
 
     packages_path = yaml.safe_load((root_dir / "dbt_project.yml").read_text()).get(

--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -39,9 +39,13 @@ current_dir = Path.cwd()
 @app.command(name="list-yaml-duplicates")
 def identify_duplicate_keys(
     path: Annotated[Path, typer.Option("--path", "-p", help="The path to the dbt project")] = current_dir,
+    exclude: Annotated[
+        Optional[List[str]],
+        typer.Option("--exclude", "-e", help="YAML files or directories to exclude, relative to --path"),
+    ] = None,
 ):
     print(f"[green]Identifying duplicates in {path}[/green]\n")
-    project_duplicates, package_duplicates = find_duplicate_keys(path)
+    project_duplicates, package_duplicates = find_duplicate_keys(path, excluded_paths=exclude)
     print_duplicate_keys(project_duplicates, package_duplicates)
 
 

--- a/tests/unit_tests/test_duplicate_keys.py
+++ b/tests/unit_tests/test_duplicate_keys.py
@@ -134,6 +134,55 @@ models:
     assert "description" in yaml_duplicates[0].value
 
 
+def test_find_duplicate_keys_with_exclude(temp_project_dir: Path):
+    # Create a target_foo directory with duplicate YAML
+    target_foo_dir = temp_project_dir / "target_foo"
+    target_foo_dir.mkdir(parents=True, exist_ok=True)
+    target_foo_dir.joinpath("run_results.yml").write_text("""
+version: 2
+
+models:
+  - name: log_model
+    description: "First"
+    description: "Duplicate"
+""")
+
+    project_duplicates, _ = find_duplicate_keys(temp_project_dir, excluded_paths=["target_foo"])
+
+    # logs/ duplicates should be excluded, models/ duplicates should remain
+    log_duplicates = [d for d in project_duplicates if "logs" in str(d.file)]
+    assert len(log_duplicates) == 0
+    assert len(project_duplicates) == 1
+    assert project_duplicates[0].file.name == "schema.yml"
+
+
+def test_find_duplicate_keys_with_exclude_multiple(temp_project_dir: Path):
+    for dirname in ["logs", ".venv"]:
+        d = temp_project_dir / dirname
+        d.mkdir(parents=True, exist_ok=True)
+        d.joinpath("schema.yml").write_text("""
+version: 2
+
+models:
+  - name: m1
+    description: "First"
+    description: "Duplicate"
+""")
+
+    project_duplicates, _ = find_duplicate_keys(temp_project_dir, excluded_paths=["logs", ".venv"])
+
+    excluded = [d for d in project_duplicates if "logs" in str(d.file) or ".venv" in str(d.file)]
+    assert len(excluded) == 0
+    assert len(project_duplicates) == 1
+
+
+def test_find_duplicate_keys_with_exclude_no_match(temp_project_dir: Path):
+    project_duplicates, package_duplicates = find_duplicate_keys(temp_project_dir, excluded_paths=["nonexistent_dir"])
+
+    assert len(project_duplicates) == 1
+    assert len(package_duplicates) == 1
+
+
 def test_duplicate_found_str_representation():
     dup = DuplicateFound(file=Path("test.yml"), line=10, key="test_key", value="duplicate key: test_key")
     assert str(dup) == "test.yml:10 -- duplicate key: test_key"


### PR DESCRIPTION
## Description

Please describe the changes made and why they were made. Link to any relevant issues or tickets.

---

Allows excluding directories by relative path to `--path`.

Usage: `dbt-autofix list-yaml-duplicates --path /home/foo/bar/baz
--exclude some_cursed_directory --exclude foo/bad.yaml`

I tried to keep same code style/naming convention as rest of code.

What this was caused by is another bug, which is https://github.com/dbt-labs/dbt-autofix/issues/384 but this solves it in a simple way.

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [x] Updated unit tests if needed
*   [x] Tests passed when run locally
