### PR TITLE
Preserve YAML comments when moving keys during refactor

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -10,7 +10,7 @@ from dbt_autofix.refactors.results import (
     YMLContent,
     YMLRuleRefactorResult,
 )
-from dbt_autofix.refactors.yml import DbtYAML, get_dict, load_yaml
+from dbt_autofix.refactors.yml import DbtYAML, copy_key_comment, get_dict, load_yaml
 from dbt_autofix.retrieve_schemas import DbtProjectSpecs, SchemaSpecs
 
 config = """
@@ -151,6 +151,7 @@ def rec_check_yaml_path(
                     log_msg = f"Moved custom config '{k}' to '+meta'"
                     meta = get_dict(yml_dict, "+meta")
                     meta.update({k: v})
+                    copy_key_comment(yml_dict, k, meta)
                     yml_dict["+meta"] = meta
 
                 if log_msg:
@@ -185,6 +186,7 @@ def rec_check_yaml_path(
                                     log_msg = f"Moved '{subkey}' from '{k}' to '+meta' (subkeys shouldn't be +prefixed)"
                                     meta = get_dict(yml_dict, "+meta")
                                     meta[subkey] = subvalue
+                                    copy_key_comment(v, subkey, meta)
                                     yml_dict["+meta"] = meta
                                     del v[subkey]
 
@@ -198,6 +200,7 @@ def rec_check_yaml_path(
                                     log_msg = f"Moved '{subkey}' from '{k}' to '+meta' (not a valid property for {key_without_plus})"
                                     meta = get_dict(yml_dict, "+meta")
                                     meta[subkey] = subvalue
+                                    copy_key_comment(v, subkey, meta)
                                     yml_dict["+meta"] = meta
                                     del v[subkey]
 
@@ -212,6 +215,7 @@ def rec_check_yaml_path(
                     log_msg = f"Moved unrecognized config '{k}' to '+meta'"
                     meta = get_dict(yml_dict, "+meta")
                     meta.update({key_without_plus: v})
+                    copy_key_comment(yml_dict, k, meta, key_without_plus)
                     yml_dict["+meta"] = meta
                     del yml_dict[k]
 

--- a/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
@@ -10,7 +10,15 @@ from ruamel.yaml.comments import CommentedMap
 from dbt_autofix.deprecations import DeprecationType
 from dbt_autofix.refactors.constants import COMMON_CONFIG_MISSPELLINGS, COMMON_PROPERTY_MISSPELLINGS
 from dbt_autofix.refactors.results import DbtDeprecationRefactor, YMLContent, YMLRefactorConfig, YMLRuleRefactorResult
-from dbt_autofix.refactors.yml import DbtYAML, dict_to_yaml_str, get_dict, get_list, load_yaml, yaml_config
+from dbt_autofix.refactors.yml import (
+    DbtYAML,
+    copy_key_comment,
+    dict_to_yaml_str,
+    get_dict,
+    get_list,
+    load_yaml,
+    yaml_config,
+)
 from dbt_autofix.retrieve_schemas import SchemaSpecs
 
 NUM_SPACES_TO_REPLACE_TAB = 2
@@ -255,10 +263,11 @@ def restructure_owner_properties(
             if field not in schema_specs.owner_properties:
                 refactored = True
                 if "config" not in node:
-                    node["config"] = {"meta": {}}
+                    node["config"] = CommentedMap()
                 if "meta" not in node["config"]:
-                    node["config"]["meta"] = {}
+                    node["config"]["meta"] = CommentedMap()
                 node["config"]["meta"][field] = owner[field]
+                copy_key_comment(owner, field, node["config"]["meta"])
                 del owner[field]
                 refactor_logs.append(
                     f"{pretty_node_type} '{node['name']}' - Owner field '{field}' moved under config.meta."
@@ -598,6 +607,7 @@ def refactor_test_config_fields(
                     )
                 )
                 test_definition["config"] = node_config
+            copy_key_comment(test_definition, field, node_config)
             del test_definition[field]
 
     return deprecation_refactors
@@ -614,7 +624,9 @@ def refactor_test_common_misspellings(test_definition: CommentedMap, test_name: 
                     deprecation=DeprecationType.CUSTOM_KEY_IN_OBJECT_DEPRECATION,
                 )
             )
-            test_definition[COMMON_PROPERTY_MISSPELLINGS[field.lower()]] = test_definition[field]
+            corrected = COMMON_PROPERTY_MISSPELLINGS[field.lower()]
+            test_definition[corrected] = test_definition[field]
+            copy_key_comment(test_definition, field, test_definition, corrected)
             del test_definition[field]
 
     return deprecation_refactors
@@ -643,6 +655,7 @@ def refactor_test_args(test_definition: CommentedMap, test_name: str) -> List[Db
         )
         test_definition["arguments"] = get_dict(test_definition, "arguments")
         test_definition["arguments"].update({field: test_definition[field]})
+        copy_key_comment(test_definition, field, test_definition["arguments"])
         del test_definition[field]
 
     return deprecation_refactors
@@ -686,7 +699,9 @@ def restructure_yaml_keys_for_node(
                     deprecation=DeprecationType.CUSTOM_KEY_IN_CONFIG_DEPRECATION,
                 )
             )
-            node["config"][COMMON_CONFIG_MISSPELLINGS[field]] = node["config"][field]
+            corrected = COMMON_CONFIG_MISSPELLINGS[field]
+            node["config"][corrected] = node["config"][field]
+            copy_key_comment(node["config"], field, node["config"], corrected)
             del node["config"][field]
         else:
             deprecation_refactors.append(
@@ -697,6 +712,7 @@ def restructure_yaml_keys_for_node(
             )
             node_config_meta = get_dict(get_dict(node, "config"), "meta")
             node_config_meta.update({field: node["config"][field]})
+            copy_key_comment(node["config"], field, node_config_meta)
             node["config"] = get_dict(node, "config")
             node["config"].update({"meta": node_config_meta})
             del node["config"][field]
@@ -718,6 +734,7 @@ def restructure_yaml_keys_for_node(
                 )
             )
             node[correct_field] = node[field]
+            copy_key_comment(node, field, node, correct_field)
             del node[field]
             continue
 
@@ -728,6 +745,7 @@ def restructure_yaml_keys_for_node(
             # if the field is not under config, move it under config
             if field not in node_config:
                 node_config.update({field: node[field]})
+                copy_key_comment(node, field, node_config)
                 deprecation_refactors.append(
                     DbtDeprecationRefactor(
                         log=f"{pretty_node_type} '{node.get('name', '')}' - Field '{field}' moved under config.",
@@ -771,6 +789,7 @@ def restructure_yaml_keys_for_node(
                 )
             node_meta = get_dict(get_dict(node, "config"), "meta")
             node_meta.update({field: node[field]})
+            copy_key_comment(node, field, node_meta)
             node["config"] = get_dict(node, "config")
             node["config"].update({"meta": node_meta})
             del node[field]
@@ -785,11 +804,12 @@ def restructure_yaml_keys_for_node(
         )
 
         if "config" not in node:
-            node["config"] = {"meta": {}}
+            node["config"] = CommentedMap()
         if "meta" not in node["config"]:
-            node["config"]["meta"] = {}
+            node["config"]["meta"] = CommentedMap()
         for key, value in existing_meta.items():
             node["config"]["meta"].update({key: value})
+            copy_key_comment(existing_meta, key, node["config"]["meta"])
         del node["meta"]
 
     return node, refactored, deprecation_refactors

--- a/src/dbt_autofix/refactors/yml.py
+++ b/src/dbt_autofix/refactors/yml.py
@@ -43,6 +43,50 @@ class DbtYAML(YAML):
             return buf.getvalue()[:-1].decode("utf-8")
 
 
+def copy_key_comment(
+    src: CommentedMap,
+    src_key: Any,
+    dst: CommentedMap,
+    dst_key: Any = None,
+) -> None:
+    """Copies a keys inline comment when moving it between mappings.
+
+    ruamel.yaml stores a key's end-of-line comment on the parent mapping
+    (``src.ca.items[src_key]``), not on the value object, so moving only the value
+    (``dst[key] = src[key]``) drops it.
+
+    Call copy_key_comment BEFORE deleting ``src[src_key]`` to preserve the comment.
+
+    Only the actual inline comment (``key: value # note`` on the same line) is copied.
+
+    A trailing/standalone comment block (a blank line then ``# ...`` that documents whatever follows) is left in place, as
+    ruamel records it against the preceding key too, but it logically belongs to the source location, so relocating it
+    with the moved key would be wrong.
+
+    no-op when there is no inline comment or when ``dst`` cannot hold one.
+    """
+    if dst_key is None:
+        dst_key = src_key
+    src_ca = getattr(src, "ca", None)
+    if src_ca is None or src_key not in src_ca.items:
+        return
+    if not hasattr(dst, "yaml_add_eol_comment"):
+        return
+    token = src_ca.items[src_key][2]
+    if token is None:
+        return
+    # The inline comment sits on the same line as the value, so the token text
+    # starts with '#'. A standalone trailing block starts with a newline instead
+    # and logically belongs to whatever follows, so it must not move.
+    inline = token.value.split("\n", 1)[0].lstrip()
+    if not inline.startswith("#"):
+        return
+    # column=0 renders the comment one space after the value, regardless of the
+    # destination's indent (a preserved absolute column would pad oddly when the
+    # key moves to a shallower level).
+    dst.yaml_add_eol_comment(inline, key=dst_key, column=0)
+
+
 def get_list(node: CommentedMap, key: str) -> CommentedSeq:
     return node.get(key) or CommentedSeq()
 

--- a/tests/unit_tests/test_comment_preservation.py
+++ b/tests/unit_tests/test_comment_preservation.py
@@ -1,0 +1,125 @@
+"""Tests for inline-comment preservation when keys are moved between mappings.
+
+ruamel.yaml stores a key's end-of-line comment on the *parent* mapping
+(``ca.items[key]``), not on the value, so naively moving a value drops the
+comment. ``copy_key_comment`` carries the inline note across while leaving
+standalone trailing comments (which belong to whatever follows) in place.
+"""
+
+from ruamel.yaml.comments import CommentedMap
+
+from dbt_autofix.refactors.changesets.dbt_schema_yml import restructure_yaml_keys_for_node
+from dbt_autofix.refactors.yml import DbtYAML, copy_key_comment, load_yaml
+from dbt_autofix.retrieve_schemas import SchemaSpecs
+
+
+def _dump(data) -> str:
+    return DbtYAML().dump_to_string(data)
+
+
+# --- copy_key_comment unit behaviour ------------------------------------
+
+
+def test_inline_comment_moves_with_key():
+    src = load_yaml("a:\n  x: 1 # keep me\n")["a"]
+    dst = CommentedMap()
+    dst["x"] = src["x"]
+    copy_key_comment(src, "x", dst)
+    del src["x"]
+    assert _dump(dst) == "x: 1 # keep me"
+
+
+def test_inline_comment_moves_to_renamed_key():
+    src = load_yaml("a:\n  old: 1 # keep me\n")["a"]
+    src["new"] = src["old"]
+    copy_key_comment(src, "old", src, "new")
+    del src["old"]
+    assert _dump(src) == "new: 1 # keep me"
+
+
+def test_inline_comment_normalised_to_single_space():
+    # Spacing is normalised to one space so the comment renders predictably
+    # regardless of the destination's indent level.
+    src = load_yaml("a:\n  x: 1  # two spaces\n")["a"]
+    dst = CommentedMap()
+    dst["x"] = src["x"]
+    copy_key_comment(src, "x", dst)
+    assert _dump(dst) == "x: 1 # two spaces"
+
+
+def test_standalone_trailing_comment_does_not_move():
+    # The comment documents the *next* key; moving 'x' must leave it behind.
+    src = load_yaml("a:\n  x: 1\n\n  # belongs to y\n  y: 2\n")["a"]
+    dst = CommentedMap()
+    dst["x"] = src["x"]
+    copy_key_comment(src, "x", dst)
+    assert _dump(dst) == "x: 1"
+
+
+def test_mixed_inline_and_trailing_only_moves_inline():
+    src = load_yaml("a:\n  x: 1 # inline\n  # standalone\n  y: 2\n")["a"]
+    dst = CommentedMap()
+    dst["x"] = src["x"]
+    copy_key_comment(src, "x", dst)
+    assert _dump(dst) == "x: 1 # inline"
+
+
+def test_no_comment_is_a_noop():
+    src = load_yaml("a:\n  x: 1\n")["a"]
+    dst = CommentedMap()
+    dst["x"] = src["x"]
+    copy_key_comment(src, "x", dst)
+    assert "x" not in dst.ca.items
+
+
+def test_plain_dict_destination_is_a_noop():
+    src = load_yaml("a:\n  x: 1 # note\n")["a"]
+    dst = {}  # plain dict cannot hold comments
+    copy_key_comment(src, "x", dst)  # must not raise
+
+
+# --- end-to-end through restructure_yaml_keys_for_node ----------------------
+
+
+def _restructure_column(yaml_str: str) -> str:
+    specs = SchemaSpecs()
+    doc = load_yaml(yaml_str)
+    for column in doc["models"][0]["columns"]:
+        restructure_yaml_keys_for_node(column, "columns", specs)
+    return _dump(doc)
+
+
+def test_column_meta_move_preserves_comment():
+    out = _restructure_column(
+        "models:\n"
+        "  - name: model1\n"
+        "    columns:\n"
+        "      - name: column1\n"
+        "        meta:\n"
+        "          foo_bar_baz: true # my awesome comment\n"
+    )
+    assert "foo_bar_baz: true # my awesome comment" in out
+    assert "config:\n          meta:" in out
+
+
+def test_column_meta_merge_preserves_both_comments():
+    out = _restructure_column(
+        "models:\n"
+        "  - name: model1\n"
+        "    columns:\n"
+        "      - name: column1\n"
+        "        meta:\n"
+        "          a: 1 # note a\n"
+        "        config:\n"
+        "          meta:\n"
+        "            b: 2 # note b\n"
+    )
+    assert "a: 1 # note a" in out
+    assert "b: 2 # note b" in out
+
+
+def test_unknown_field_move_preserves_comment():
+    out = _restructure_column(
+        "models:\n  - name: model1\n    columns:\n      - name: column1\n        some_unknown_field: 7 # trailing note\n"
+    )
+    assert "some_unknown_field: 7 # trailing note" in out


### PR DESCRIPTION
## Description

Please describe the changes made and why they were made. Link to any relevant issues or tickets.

Fixes #354

The schema and dbt_project refactors relocate keys between mappings (custom configs and meta fields under config.meta, test args under arguments, renamed misspellings, and similar). ruamel.yaml stores a key's end-of-line comment on the parent mapping (ca.items[key]), not on the value, so moving only the value silently dropped the trailing `# ...` note.

For example:
```yaml
    meta:
      my_super_awesome_key: true # Some comment
```
became:
```yaml
    config:
      meta:
      my_super_awesome_key: true
```

Losing the explanatory comment that documents the field.

This adds a new function `copy_key_comment(src, src_key, dst, dst_key=None)` in `refactors/yml.py` and we have to call it at every key-move site in `dbt_schema_yml.py` and `dbt_project_yml.py`, immediately BEFORE the source key is deleted.

It copies only the genuine inline comment (the note on the same line as the value).

A standalone trailing comment block (a blank line then `# ...` that documents whatever follows) is left in place: ruamel records it against the preceding key, but it logically belongs to the source location, so relocating it with the moved key would be wrong.

Two supporting fixes were required:

- The comment merge target `node["config"]["meta"]` was built as a plain dict literal, which cannot hold ruamel comments at all; it is now a CommentedMap.
- The comment is re-emitted at column 0 so it renders one space after the value regardless of the destination indent. Preserving the original absolute column padded oddly when a key moved to a shallower level.

I added some tests to `tests/unit_tests/test_comment_preservation.py` covering the helper directly (inline moves, rename, single-space normalisation, standalone-stays, mixed-inline-and-trailing, no-op cases) and end-to-end through `restructure_yaml_keys_for_node` (meta move, merge into existing config.meta, unknown-field move).

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [x] Updated unit tests if needed
*   [x] Tests passed when run locally

---

Please test this, it worked for our repository, but would love some more funkier YAML, which we can update the tests with.

Again, I tried to make this an isolated function so it's easier to test/debug.