### PR TITLE
Read package lock file during package upgrades

### DIFF
--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -22,7 +22,7 @@ from dbt_autofix.packages.dbt_package_file import (
     parse_package_dependencies_from_dependencies_yml,
     parse_package_dependencies_from_packages_yml,
 )
-from dbt_autofix.packages.dbt_package_lock_file import DbtPackageLockFile
+from dbt_autofix.packages.dbt_package_lock_file import DbtPackageLockFile, load_yaml_from_package_lock_file_path
 from dbt_autofix.packages.dbt_package_text_file import DbtPackageTextFile
 from dbt_autofix.packages.installed_packages import get_current_installed_package_versions
 
@@ -156,8 +156,15 @@ def generate_package_dependencies(root_dir: Path) -> Optional[DbtPackageFile]:
         return
 
     # check package-lock.yml
-    package_lock_file: DbtPackageLockFile = DbtPackageLockFile(file_path=(root_dir / "package-lock.yml"))
-    console.log(f"Package lock file package versions: {[x for x in package_lock_file.installed_package_versions]}")
+    package_lock_path: Path = (root_dir / "package-lock.yml")
+    package_lock_yml: Optional[dict[Any, Any]] = load_yaml_from_package_lock_file_path(package_lock_path)
+    if not package_lock_yml:
+        console.log(f"package-lock.yml not found in {root_dir}. For the most accurate results, please run dbt deps and generate a lock file. Proceeding anyway")
+    else:
+        package_lock_file: DbtPackageLockFile = DbtPackageLockFile(yml_dependencies=package_lock_yml)
+        console.log(f"Package lock file package versions: {[x for x in package_lock_file.installed_package_versions]}")
+        if package_lock_file:
+            deps_file.merge_package_lock_versions(package_lock_file)
 
     # check installed packages
     installed_packages: dict[str, DbtPackageVersion] = get_current_installed_package_versions(root_dir)

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -156,13 +156,14 @@ def generate_package_dependencies(root_dir: Path) -> Optional[DbtPackageFile]:
         return
 
     # check package-lock.yml
-    package_lock_path: Path = (root_dir / "package-lock.yml")
+    package_lock_path: Path = root_dir / "package-lock.yml"
     package_lock_yml: Optional[dict[Any, Any]] = load_yaml_from_package_lock_file_path(package_lock_path)
     if not package_lock_yml:
-        console.log(f"package-lock.yml not found in {root_dir}. For the most accurate results, please run dbt deps and generate a lock file. Proceeding anyway")
+        console.log(
+            f"package-lock.yml not found in {root_dir}. For the most accurate results, please run dbt deps and generate a lock file. Proceeding anyway"
+        )
     else:
         package_lock_file: DbtPackageLockFile = DbtPackageLockFile(yml_dependencies=package_lock_yml)
-        console.log(f"Package lock file package versions: {[x for x in package_lock_file.installed_package_versions]}")
         if package_lock_file:
             deps_file.merge_package_lock_versions(package_lock_file)
 

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -22,6 +22,7 @@ from dbt_autofix.packages.dbt_package_file import (
     parse_package_dependencies_from_dependencies_yml,
     parse_package_dependencies_from_packages_yml,
 )
+from dbt_autofix.packages.dbt_package_lock_file import DbtPackageLockFile
 from dbt_autofix.packages.dbt_package_text_file import DbtPackageTextFile
 from dbt_autofix.packages.installed_packages import get_current_installed_package_versions
 
@@ -153,6 +154,11 @@ def generate_package_dependencies(root_dir: Path) -> Optional[DbtPackageFile]:
     if not deps_file:
         error_console.log("Project dependencies could not be parsed")
         return
+
+    # check package-lock.yml
+    package_lock_file: DbtPackageLockFile = DbtPackageLockFile(file_path=(root_dir / "package-lock.yml"))
+    console.log(f"Package lock file package versions: {[x for x in package_lock_file.installed_package_versions]}")
+
     # check installed packages
     installed_packages: dict[str, DbtPackageVersion] = get_current_installed_package_versions(root_dir)
 

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -9,7 +9,7 @@ from dbt_fusion_package_tools.upgrade_status import (
     PackageFusionCompatibilityState,
     PackageVersionFusionCompatibilityState,
 )
-from dbt_fusion_package_tools.version_utils import Matchers, VersionSpecifier
+from dbt_fusion_package_tools.version_utils import Matchers
 from rich.console import Console
 
 from dbt_autofix.packages.dbt_package_lock_file import DbtPackageLockFile
@@ -155,23 +155,23 @@ class DbtPackageFile:
 
     def add_version_for_package(self, package_id: str, package_version: DbtPackageVersion, installed=False) -> bool:
         return self.package_dependencies[package_id].add_package_version(package_version, installed=installed)
-    
+
     def merge_package_lock_versions(self, lock_file: DbtPackageLockFile) -> int:
         package_lock_found_in_deps: int = 0
         for lock_file_package in lock_file.installed_package_versions:
             lock_package_id: Optional[str] = lock_file.installed_package_versions[lock_file_package].package_id
             if lock_package_id is None or lock_package_id != lock_file_package:
-                console.log(f"Mismatch in lock package: {lock_package_id}, {lock_file_package}")
                 lock_package_id = lock_package_id if lock_package_id is not None else lock_file_package
-            lock_package_version: VersionSpecifier = lock_file.installed_package_versions[lock_file_package].version
-            console.log(f"Parsed package version info: {lock_file_package}, {lock_package_id}, {lock_package_version}")
             if lock_file_package in self.package_dependencies:
-                self.set_installed_version_for_package(lock_package_id, lock_file.installed_package_versions[lock_package_id])
+                self.set_installed_version_for_package(
+                    lock_package_id, lock_file.installed_package_versions[lock_package_id]
+                )
                 package_lock_found_in_deps += 1
             else:
                 self.transitive_dependencies[lock_package_id] = lock_file.installed_package_versions[lock_file_package]
-        console.log(f"found {package_lock_found_in_deps} lock file deps in packages.yml and {len(self.transitive_dependencies)} transitive dependencies")
-        assert package_lock_found_in_deps + len(self.transitive_dependencies) == len(lock_file.installed_package_versions)
+        assert package_lock_found_in_deps + len(self.transitive_dependencies) == len(
+            lock_file.installed_package_versions
+        )
         return package_lock_found_in_deps
 
     def merge_installed_versions(self, installed_packages: dict[str, DbtPackageVersion]) -> int:
@@ -186,10 +186,7 @@ class DbtPackageFile:
             # skip if we've already determined the version, such as from the package lock
             if self.package_dependencies[package_id].installed_package_version is not None:
                 installed_count += 1
-                console.log(f"installed package {package} already has version {self.package_dependencies[package_id].installed_package_version}")
                 continue
-            else:
-                console.log(f"no version found from package lock for {package_id}")
             # kind of hacky - try to correct installed version if package's dbt project yml
             # has an incorrect version
             package_version_range = self.package_dependencies[package_id].project_config_version_range

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -9,9 +9,10 @@ from dbt_fusion_package_tools.upgrade_status import (
     PackageFusionCompatibilityState,
     PackageVersionFusionCompatibilityState,
 )
-from dbt_fusion_package_tools.version_utils import Matchers
+from dbt_fusion_package_tools.version_utils import Matchers, VersionSpecifier
 from rich.console import Console
 
+from dbt_autofix.packages.dbt_package_lock_file import DbtPackageLockFile
 from dbt_autofix.refactors.yml import load_yaml
 
 console = Console()
@@ -115,6 +116,7 @@ class DbtPackageFile:
     yml_dependencies: dict[Any, Any]
     # this is indexed by package id for uniqueness (hopefully)
     package_dependencies: dict[str, DbtPackage] = field(default_factory=dict)
+    transitive_dependencies: dict[str, DbtPackageVersion] = field(default_factory=dict)
     unknown_packages: set[str] = field(default_factory=set)
 
     def parse_file_path_to_string(self):
@@ -153,6 +155,24 @@ class DbtPackageFile:
 
     def add_version_for_package(self, package_id: str, package_version: DbtPackageVersion, installed=False) -> bool:
         return self.package_dependencies[package_id].add_package_version(package_version, installed=installed)
+    
+    def merge_package_lock_versions(self, lock_file: DbtPackageLockFile) -> int:
+        package_lock_found_in_deps: int = 0
+        for lock_file_package in lock_file.installed_package_versions:
+            lock_package_id: Optional[str] = lock_file.installed_package_versions[lock_file_package].package_id
+            if lock_package_id is None or lock_package_id != lock_file_package:
+                console.log(f"Mismatch in lock package: {lock_package_id}, {lock_file_package}")
+                lock_package_id = lock_package_id if lock_package_id is not None else lock_file_package
+            lock_package_version: VersionSpecifier = lock_file.installed_package_versions[lock_file_package].version
+            console.log(f"Parsed package version info: {lock_file_package}, {lock_package_id}, {lock_package_version}")
+            if lock_file_package in self.package_dependencies:
+                self.set_installed_version_for_package(lock_package_id, lock_file.installed_package_versions[lock_package_id])
+                package_lock_found_in_deps += 1
+            else:
+                self.transitive_dependencies[lock_package_id] = lock_file.installed_package_versions[lock_file_package]
+        console.log(f"found {package_lock_found_in_deps} lock file deps in packages.yml and {len(self.transitive_dependencies)} transitive dependencies")
+        assert package_lock_found_in_deps + len(self.transitive_dependencies) == len(lock_file.installed_package_versions)
+        return package_lock_found_in_deps
 
     def merge_installed_versions(self, installed_packages: dict[str, DbtPackageVersion]) -> int:
         package_lookup: dict[str, str] = self.get_reverse_lookup_by_package_name()

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -183,6 +183,13 @@ class DbtPackageFile:
                 self.unknown_packages.add(package)
                 continue
             package_id = package_lookup[package]
+            # skip if we've already determined the version, such as from the package lock
+            if self.package_dependencies[package_id].installed_package_version is not None:
+                installed_count += 1
+                console.log(f"installed package {package} already has version {self.package_dependencies[package_id].installed_package_version}")
+                continue
+            else:
+                console.log(f"no version found from package lock for {package_id}")
             # kind of hacky - try to correct installed version if package's dbt project yml
             # has an incorrect version
             package_version_range = self.package_dependencies[package_id].project_config_version_range

--- a/tests/unit_tests/package_upgrades/test_package_upgrade.py
+++ b/tests/unit_tests/package_upgrades/test_package_upgrade.py
@@ -16,6 +16,7 @@ from dbt_autofix.package_upgrade import (
 )
 from dbt_autofix.packages.dbt_package_file import DbtPackageFile
 
+# project does not have a package lock file
 PROJECT_WITH_PACKAGES_PATH = Path("tests/integration_tests/package_upgrades/mixed_versions")
 # update if count changes
 PROJECT_DEPENDENCY_COUNT = 10
@@ -32,6 +33,7 @@ PROJECT_DEPENDENCY_COUNT = 10
 # dbt-labs/snowplow 0.9.0: no upgrade needed (version 0.9.0 has compatible require dbt version)
 
 # needs upgrade to version within config range (should always succeed)
+# packages.yml has a version range (not pinned) so installed version will be inferred as 0.2.1
 # Matts52/dbt_set_similarity 0.2.1: upgrade needed (versions 0.2.2+ compatible)
 # dbt_project.yml require-dbt-version: [">=1.1.0", "<2.0.0"]
 
@@ -59,6 +61,8 @@ def test_generate_package_dependencies():
     assert output is not None
     assert len(output.package_dependencies) == PROJECT_DEPENDENCY_COUNT
     assert len(output.get_private_package_names()) == 0
+    # without package lock file, no transitive dependencies inferred
+    assert len(output.transitive_dependencies) == 0
     for package in output.package_dependencies:
         assert output.package_dependencies[package].get_installed_package_version() != "unknown"
         fusion_compatibility_state = output.package_dependencies[package].is_installed_version_fusion_compatible()

--- a/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
+++ b/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Optional
 
+from dbt_fusion_package_tools.dbt_package import DbtPackage
 from dbt_fusion_package_tools.upgrade_status import (
     PackageFusionCompatibilityState,
     PackageVersionFusionCompatibilityState,
@@ -15,8 +16,6 @@ from dbt_autofix.package_upgrade import (
     upgrade_package_versions,
 )
 from dbt_autofix.packages.dbt_package_file import DbtPackageFile
-from dbt_fusion_package_tools.dbt_package import DbtPackage
-from dbt_fusion_package_tools.version_utils import VersionSpecifier
 
 PROJECT_WITH_PACKAGE_LOCK_PATH = Path("tests/integration_tests/package_upgrades/transitive_dependencies")
 # update if count changes
@@ -41,8 +40,6 @@ def test_generate_package_dependencies():
         assert output.package_dependencies[package].installed_package_version is not None
         assert output.package_dependencies[package].get_installed_package_version() != "unknown"
         assert output.package_dependencies[package].project_config_version_range is not None
-        project_config_version_range_start = output.package_dependencies[package].project_config_version_range.start
-        project_config_version_range_end = output.package_dependencies[package].project_config_version_range.end
         fusion_compatibility_state = output.package_dependencies[package].is_installed_version_fusion_compatible()
         package_fusion_compatibility_state: PackageFusionCompatibilityState = output.package_dependencies[
             package
@@ -51,27 +48,27 @@ def test_generate_package_dependencies():
         # package-lock resolves to 1.4.0
         if package == "dbt-labs/dbt_utils":
             assert output.package_dependencies[package].get_installed_package_version() == "1.4.0"
-            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == "['>=1.0.0', '<2.0.0']"
-            assert project_config_version_range_start == VersionSpecifier.from_version_string("1.0.0")
-            assert project_config_version_range_end == VersionSpecifier.from_version_string("2.0.0")
+            assert (
+                str(output.package_dependencies[package].project_config_raw_version_specifier)
+                == "['>=1.0.0', '<2.0.0']"
+            )
             assert fusion_compatibility_state == PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW
             assert package_fusion_compatibility_state == PackageFusionCompatibilityState.ALL_VERSIONS_COMPATIBLE
         # packages.yml: [">=1.1.0", "<1.1.2"]
         # package-lock resolves to 1.1.1
         elif package == "dbt-labs/dbt_project_evaluator":
             assert output.package_dependencies[package].get_installed_package_version() == "1.1.1"
-            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == "['>=1.1.0', '<1.1.2']"
-            assert project_config_version_range_start == VersionSpecifier.from_version_string("1.1.0")
-            assert project_config_version_range_end == VersionSpecifier.from_version_string("1.1.2")
+            assert (
+                str(output.package_dependencies[package].project_config_raw_version_specifier)
+                == "['>=1.1.0', '<1.1.2']"
+            )
             assert fusion_compatibility_state == PackageVersionFusionCompatibilityState.EXPLICIT_DISALLOW
             assert package_fusion_compatibility_state == PackageFusionCompatibilityState.SOME_VERSIONS_COMPATIBLE
         # packages.yml: "2.6.0"
         # package-lock resolves to 2.6.0
         elif package == "fivetran/ad_reporting":
             assert output.package_dependencies[package].get_installed_package_version() == "2.6.0"
-            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == '2.6.0'
-            assert project_config_version_range_start == VersionSpecifier.from_version_string("2.6.0")
-            assert project_config_version_range_end == VersionSpecifier.from_version_string("2.6.0")
+            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == "2.6.0"
             assert fusion_compatibility_state == PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW
             assert package_fusion_compatibility_state == PackageFusionCompatibilityState.ALL_VERSIONS_COMPATIBLE
         else:

--- a/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
+++ b/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
@@ -15,6 +15,8 @@ from dbt_autofix.package_upgrade import (
     upgrade_package_versions,
 )
 from dbt_autofix.packages.dbt_package_file import DbtPackageFile
+from dbt_fusion_package_tools.dbt_package import DbtPackage
+from dbt_fusion_package_tools.version_utils import VersionSpecifier
 
 PROJECT_WITH_PACKAGE_LOCK_PATH = Path("tests/integration_tests/package_upgrades/transitive_dependencies")
 # update if count changes
@@ -28,20 +30,52 @@ PROJECT_TRANSITIVE_DEPENDENCY_COUNT = 13
 def test_generate_package_dependencies():
     output: Optional[DbtPackageFile] = generate_package_dependencies(PROJECT_WITH_PACKAGE_LOCK_PATH)
     assert output is not None
+    assert isinstance(output.package_dependencies, dict)
+    for package in output.package_dependencies:
+        assert isinstance(output.package_dependencies[package], DbtPackage)
     assert len(output.package_dependencies) == PROJECT_DEPENDENCY_COUNT
+    assert len(output.transitive_dependencies) == PROJECT_TRANSITIVE_DEPENDENCY_COUNT
     assert len(output.get_private_package_names()) == 0
     for package in output.package_dependencies:
+        # check that the correct package version is identified based on lock file
+        assert output.package_dependencies[package].installed_package_version is not None
         assert output.package_dependencies[package].get_installed_package_version() != "unknown"
+        assert output.package_dependencies[package].project_config_version_range is not None
+        project_config_version_range_start = output.package_dependencies[package].project_config_version_range.start
+        project_config_version_range_end = output.package_dependencies[package].project_config_version_range.end
         fusion_compatibility_state = output.package_dependencies[package].is_installed_version_fusion_compatible()
         package_fusion_compatibility_state: PackageFusionCompatibilityState = output.package_dependencies[
             package
         ].get_package_fusion_compatibility_state()
+        # packages.yml: [">=1.0.0", "<2.0.0"]
+        # package-lock resolves to 1.4.0
         if package == "dbt-labs/dbt_utils":
+            assert output.package_dependencies[package].get_installed_package_version() == "1.4.0"
+            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == "['>=1.0.0', '<2.0.0']"
+            assert project_config_version_range_start == VersionSpecifier.from_version_string("1.0.0")
+            assert project_config_version_range_end == VersionSpecifier.from_version_string("2.0.0")
             assert fusion_compatibility_state == PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW
             assert package_fusion_compatibility_state == PackageFusionCompatibilityState.ALL_VERSIONS_COMPATIBLE
+        # packages.yml: [">=1.1.0", "<1.1.2"]
+        # package-lock resolves to 1.1.1
         elif package == "dbt-labs/dbt_project_evaluator":
+            assert output.package_dependencies[package].get_installed_package_version() == "1.1.1"
+            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == "['>=1.1.0', '<1.1.2']"
+            assert project_config_version_range_start == VersionSpecifier.from_version_string("1.1.0")
+            assert project_config_version_range_end == VersionSpecifier.from_version_string("1.1.2")
             assert fusion_compatibility_state == PackageVersionFusionCompatibilityState.EXPLICIT_DISALLOW
             assert package_fusion_compatibility_state == PackageFusionCompatibilityState.SOME_VERSIONS_COMPATIBLE
+        # packages.yml: "2.6.0"
+        # package-lock resolves to 2.6.0
+        elif package == "fivetran/ad_reporting":
+            assert output.package_dependencies[package].get_installed_package_version() == "2.6.0"
+            assert str(output.package_dependencies[package].project_config_raw_version_specifier) == '2.6.0'
+            assert project_config_version_range_start == VersionSpecifier.from_version_string("2.6.0")
+            assert project_config_version_range_end == VersionSpecifier.from_version_string("2.6.0")
+            assert fusion_compatibility_state == PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW
+            assert package_fusion_compatibility_state == PackageFusionCompatibilityState.ALL_VERSIONS_COMPATIBLE
+        else:
+            raise ValueError(f"Unknown package: {package}")
 
 
 def test_check_for_package_upgrades():


### PR DESCRIPTION
## Description

This change improves the package upgrade logic by incorporating canonical package versions from a package lock file when available. This will let us more reliably pinpoint the actual installed package versions, including versions that are installed during transitive package dependency resolution. However it still allows the upgrade to happen if a package lock file is not found, which falls back to the original behavior of triangulating from the version range and installed package files.

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [x] Updated unit tests if needed
*   [ ] Tests passed when run locally
