### PR TITLE
Fixed existing meta key value lists from being quoted

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -231,6 +231,16 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
         deprecation_refactors=deprecation_refactors,
     )
 
+def stringify_value(v):
+    if isinstance(v, str):
+        return v
+    elif isinstance(v, list):
+        new_v = []
+        for item in v:
+            new_v.append(stringify_value(item))
+        return new_v
+    else:
+        return repr(v)
 
 def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
     """Move custom configs to meta in SQL files."""
@@ -308,7 +318,7 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
 
                     try:
                         parsed_meta = ast.literal_eval(existing_meta)
-                        meta_dict = {k: repr(v) if not isinstance(v, str) else f"'{v}'" for k, v in parsed_meta.items()}
+                        meta_dict = {k: stringify_value(v) for k, v in parsed_meta.items()}
                     except (ValueError, SyntaxError):
                         # Parsing failed, skip this meta (might contain Jinja)
                         meta_dict = {}

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -235,10 +235,7 @@ def stringify_value(v):
     if isinstance(v, str):
         return v
     elif isinstance(v, list):
-        new_v = []
-        for item in v:
-            new_v.append(stringify_value(item))
-        return new_v
+        return [stringify_value(item) for item in v]
     else:
         return repr(v)
 

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -232,7 +232,7 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
     )
 
 
-def stringify_value(v):
+def meta_transform_value(v):
     if isinstance(v, str):
         return v
     elif isinstance(v, list):
@@ -317,7 +317,7 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
 
                     try:
                         parsed_meta = ast.literal_eval(existing_meta)
-                        meta_dict = {k: stringify_value(v) for k, v in parsed_meta.items()}
+                        meta_dict = {k: meta_transform_value(v) for k, v in parsed_meta.items()}
                     except (ValueError, SyntaxError):
                         # Parsing failed, skip this meta (might contain Jinja)
                         meta_dict = {}

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -236,7 +236,7 @@ def meta_transform_value(v):
     if isinstance(v, str):
         return v
     elif isinstance(v, list):
-        return [stringify_value(item) for item in v]
+        return [meta_transform_value(item) for item in v]
     else:
         return repr(v)
 

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -231,6 +231,7 @@ def remove_unmatched_endings(content: SQLContent, config: SQLRefactorConfig) -> 
         deprecation_refactors=deprecation_refactors,
     )
 
+
 def stringify_value(v):
     if isinstance(v, str):
         return v
@@ -238,6 +239,7 @@ def stringify_value(v):
         return [stringify_value(item) for item in v]
     else:
         return repr(v)
+
 
 def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
     """Move custom configs to meta in SQL files."""

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -2807,3 +2807,30 @@ select 1 as id
         assert "meta" in result.deprecation_refactors[0].log
         # Verify Jinja function call is preserved
         assert "get_warehouse('medium')" in result.refactored_content
+
+    def test_multiple_custom_configs_with_jinja_moved_to_meta_that_already_contained_a_list(self, schema_specs: SchemaSpecs):
+          """Test that multiple custom configs ARE moved to meta that already contains a list even with Jinja (static analysis)"""
+          sql_content = """{{ config(
+      doot='burger',
+      on_column='city',
+      nugget=['chicken'],
+      meta={'attributes': [['A', 'B', 'C', 'D'], ['X', 'Y', 'Z'], []], 'cool': 'beans'},
+) }}
+
+select 1 as id
+  """
+          expected_content = """{{ config(
+    meta={'attributes': [['A', 'B', 'C', 'D'], ['X', 'Y', 'Z'], []], 'cool': 'beans', 'doot': 'burger', 'on_column': 'city', 'nugget': ['chicken']}
+) }}
+
+select 1 as id
+  """
+          result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+          assert result.refactored
+          assert result.refactored_content == expected_content
+          assert len(result.deprecation_refactors) == 1
+          assert "doot" in result.deprecation_refactors[0].log
+          assert "on_column" in result.deprecation_refactors[0].log
+          assert "nugget" in result.deprecation_refactors[0].log
+          assert "meta" in result.deprecation_refactors[0].log

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -2808,9 +2808,11 @@ select 1 as id
         # Verify Jinja function call is preserved
         assert "get_warehouse('medium')" in result.refactored_content
 
-    def test_multiple_custom_configs_with_jinja_moved_to_meta_that_already_contained_a_list(self, schema_specs: SchemaSpecs):
-          """Test that multiple custom configs ARE moved to meta that already contains a list even with Jinja (static analysis)"""
-          sql_content = """{{ config(
+    def test_multiple_custom_configs_with_jinja_moved_to_meta_that_already_contained_a_list(
+        self, schema_specs: SchemaSpecs
+    ):
+        """Test that multiple custom configs ARE moved to meta that already contains a list even with Jinja (static analysis)"""
+        sql_content = """{{ config(
       doot='burger',
       on_column='city',
       nugget=['chicken'],
@@ -2819,18 +2821,18 @@ select 1 as id
 
 select 1 as id
   """
-          expected_content = """{{ config(
+        expected_content = """{{ config(
     meta={'attributes': [['A', 'B', 'C', 'D'], ['X', 'Y', 'Z'], []], 'cool': 'beans', 'doot': 'burger', 'on_column': 'city', 'nugget': ['chicken']}
 ) }}
 
 select 1 as id
   """
-          result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
 
-          assert result.refactored
-          assert result.refactored_content == expected_content
-          assert len(result.deprecation_refactors) == 1
-          assert "doot" in result.deprecation_refactors[0].log
-          assert "on_column" in result.deprecation_refactors[0].log
-          assert "nugget" in result.deprecation_refactors[0].log
-          assert "meta" in result.deprecation_refactors[0].log
+        assert result.refactored
+        assert result.refactored_content == expected_content
+        assert len(result.deprecation_refactors) == 1
+        assert "doot" in result.deprecation_refactors[0].log
+        assert "on_column" in result.deprecation_refactors[0].log
+        assert "nugget" in result.deprecation_refactors[0].log
+        assert "meta" in result.deprecation_refactors[0].log


### PR DESCRIPTION
## Description

When autofix ran on this existing code:
```
{{ config(
      on_column='city',
      meta={'attributes': ['A', 'B', 'C', 'D']}
) }}
```

it would put quotes around the list the existing list value:
```
{{ config(
      meta={'attributes': '['A', 'B', 'C', 'D']', 'on_column': 'city'}
) }}
```
which is invalid.

This PR solves that by not calling `repr` if the value is a list and just simply storing it as a list in the `meta_dict`.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
