### PR TITLE
fix: migrate use_approximate_percentile to its own key, not percentile_type

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_schema_yml_semantic_layer.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_schema_yml_semantic_layer.py
@@ -585,17 +585,12 @@ def get_or_create_metric_for_measure(
     if agg_params := artificial_metric.pop("agg_params", None):
         if agg_percentile := agg_params.get("percentile"):
             artificial_metric["percentile"] = agg_percentile
-        # this must EITHER be discrete or approximate, but not both.  If both, we will fail.
-        use_discrete_percentile = agg_params.get("use_discrete_percentile")
-        use_approximate_percentile = agg_params.get("use_approximate_percentile")
-        if use_discrete_percentile and use_approximate_percentile:
-            raise ValueError(
-                f"Both use_discrete_percentile and use_approximate_percentile cannot be true for measure {measure_name}"
-            )
-        if use_discrete_percentile:
+        # discrete/continuous and approximate/exact are independent axes in the new spec:
+        # percentile_type carries discrete vs continuous, use_approximate_percentile is separate.
+        if agg_params.get("use_discrete_percentile"):
             artificial_metric["percentile_type"] = "discrete"
-        if use_approximate_percentile:
-            artificial_metric["percentile_type"] = "approximate"
+        if agg_params.get("use_approximate_percentile"):
+            artificial_metric["use_approximate_percentile"] = True
 
     semantic_definitions.record_artificial_metric(
         measure_name=measure_name,

--- a/tests/integration_tests/dbt_projects/project_semantic_layer_expected/models/customers.yml
+++ b/tests/integration_tests/dbt_projects/project_semantic_layer_expected/models/customers.yml
@@ -79,7 +79,7 @@ models:
         type: simple
         hidden: true
         percentile: 0.95
-        percentile_type: approximate
+        use_approximate_percentile: true
       - name: average_order_value
         description: LTV pre-tax / number of orders
         label: Average Order Value


### PR DESCRIPTION
## Summary
- `percentile_type` only carries the discrete/continuous axis under the new semantic layer spec. Autofix was migrating legacy `agg_params.use_approximate_percentile: true` into `percentile_type: approximate`, which is not a valid enum value and gets rejected by the parser.
- Fixes this by emitting the new, independent `use_approximate_percentile` boolean key instead, and drops the discrete/approximate mutual-exclusivity check since the two are now orthogonal axes (a metric can be discrete *and* approximate).
- Updates the golden test fixture that had baked in the invalid `percentile_type: approximate` output.

Reported in Slack: https://dbt-labs.slack.com/archives/C03KHQRQUBX/p1782869250611269 (Bilt Rewards, BigQuery median metric migration).

**⚠️ Do not merge until a Fusion/v2 release ships with support for the new `use_approximate_percentile` field: https://github.com/dbt-labs/fs/pull/11657.** Until that lands, this change would make autofix emit a key that Fusion doesn't yet recognize.

## Test plan
- [x] `uv run pytest tests/ -k "semantic_layer or percentile"` — passes
- [x] `uv run pytest tests/` — full suite passes (587 passed)