### PR TITLE
fix(dbt_project): rename +pre_hook/+post_hook to hyphenated form instead of moving to +meta

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 
 import yamllint.config
 
+from dbt_autofix.refactors.constants import DBT_PROJECT_CONFIG_MISSPELLINGS
 from dbt_autofix.refactors.results import (
     DbtDeprecationRefactor,
     DbtProjectYMLRefactorConfig,
@@ -132,8 +133,19 @@ def rec_check_yaml_path(
         if not (path / k).exists() and not _path_exists_as_file(path / k):
             # Case 1: Key doesn't have "+" prefix
             if not k.startswith("+"):
+                # Underscore hook form without "+" (pre_hook/post_hook): rename to the hyphenated,
+                # "+"-prefixed form dbt_project.yml expects, rather than treating it as custom config.
+                if (
+                    k not in node_fields.allowed_config_fields_dbt_project
+                    and k in DBT_PROJECT_CONFIG_MISSPELLINGS
+                    and DBT_PROJECT_CONFIG_MISSPELLINGS[k] in node_fields.allowed_config_fields_dbt_project
+                    and f"+{DBT_PROJECT_CONFIG_MISSPELLINGS[k]}" not in yml_dict
+                ):
+                    new_k = f"+{DBT_PROJECT_CONFIG_MISSPELLINGS[k]}"
+                    yml_dict[new_k] = v
+                    log_msg = f"Renamed config '{k}' to '{new_k}' (dbt_project.yml expects the hyphenated hook form)"
                 # Built-in config missing "+"
-                if k in node_fields.allowed_config_fields_dbt_project:
+                elif k in node_fields.allowed_config_fields_dbt_project:
                     new_k = f"+{k}"
                     yml_dict[new_k] = v
                     log_msg = f"Added '+' in front of the nested config '{k}'"
@@ -165,8 +177,29 @@ def rec_check_yaml_path(
             else:
                 key_without_plus = k[1:]  # Remove the + prefix
 
+                # Underscore hook form (+pre_hook/+post_hook): not valid in dbt_project.yml, but a
+                # functional hook in dbt-core and node-level configs. Rename to the hyphenated form
+                # instead of moving it to +meta (which would silently disable the hook).
+                if (
+                    key_without_plus not in node_fields.allowed_config_fields_dbt_project
+                    and key_without_plus in DBT_PROJECT_CONFIG_MISSPELLINGS
+                    and DBT_PROJECT_CONFIG_MISSPELLINGS[key_without_plus]
+                    in node_fields.allowed_config_fields_dbt_project
+                    and f"+{DBT_PROJECT_CONFIG_MISSPELLINGS[key_without_plus]}" not in yml_dict
+                ):
+                    corrected_key = f"+{DBT_PROJECT_CONFIG_MISSPELLINGS[key_without_plus]}"
+                    log_msg = (
+                        f"Renamed config '{k}' to '{corrected_key}' (dbt_project.yml expects the hyphenated hook form)"
+                    )
+                    yml_dict[corrected_key] = v
+                    del yml_dict[k]
+                    if refactor_logs is None:
+                        refactor_logs = [log_msg]
+                    else:
+                        refactor_logs.append(log_msg)
+
                 # Check if it's a valid config field
-                if key_without_plus in node_fields.allowed_config_fields_dbt_project:
+                elif key_without_plus in node_fields.allowed_config_fields_dbt_project:
                     # Valid config, but we need to check if it's a dict with +prefixed subkeys
                     if isinstance(v, dict) and schema_specs is not None:
                         # Get dict config analysis

--- a/src/dbt_autofix/refactors/constants.py
+++ b/src/dbt_autofix/refactors/constants.py
@@ -7,3 +7,11 @@ COMMON_PROPERTY_MISSPELLINGS = {
 
 # Used for schema.yml and SQL files - convert hyphen to underscore
 COMMON_CONFIG_MISSPELLINGS = {"post-hook": "post_hook", "pre-hook": "pre_hook"}
+
+# Used for dbt_project.yml - convert underscore to hyphen.
+# dbt_project.yml expects the hyphenated hook keys (+pre-hook / +post-hook), unlike node-level
+# configs (schema.yml / SQL config()) where the underscore form is canonical. Users frequently use
+# the underscore form in dbt_project.yml as well; without this normalization it is treated as an
+# unknown config and moved to +meta, which silently disables a functional hook. Map it back to the
+# hyphenated form instead.
+DBT_PROJECT_CONFIG_MISSPELLINGS = {"pre_hook": "pre-hook", "post_hook": "post-hook"}

--- a/tests/unit_tests/test_rec_check_yaml_path.py
+++ b/tests/unit_tests/test_rec_check_yaml_path.py
@@ -93,26 +93,41 @@ def test_correct_configs_unchanged(models_node_fields, temp_path):
 # =============================================================================
 
 
-def test_unsupported_hook_moved_to_meta(models_node_fields, temp_path):
-    """INPUT:  +post_hook with underscore (NOT in schema)
-    OUTPUT: Moved to +meta.post_hook
-    WHY:    Schema doesn't recognize post_hook, so it's treated as custom config
+def test_underscore_hook_renamed_to_hyphen(models_node_fields, temp_path):
+    """INPUT:  +post_hook / +pre_hook with underscore (NOT in dbt_project.yml schema)
+    OUTPUT: Renamed to +post-hook / +pre-hook
+    WHY:    The underscore form is a functional hook in dbt-core; dbt_project.yml expects the
+            hyphenated form. Renaming preserves the hook instead of burying it in +meta.
     """
     input_dict = {"+post_hook": "grant select", "+pre_hook": "begin"}
 
     expected_output = {
-        "+meta": {
-            "post_hook": "grant select",  # Moved to meta
-            "pre_hook": "begin",  # Moved to meta
-        }
+        "+post-hook": "grant select",  # Renamed, not moved to meta
+        "+pre-hook": "begin",  # Renamed, not moved to meta
     }
 
     result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
 
     assert result == expected_output
     assert len(logs) == 2
+    assert "+post_hook" in logs[0] and "+post-hook" in logs[0]
+    assert "+pre_hook" in logs[1] and "+pre-hook" in logs[1]
+
+
+def test_underscore_hook_kept_in_meta_when_hyphen_form_already_present(models_node_fields, temp_path):
+    """INPUT:  Both +post-hook (valid) and +post_hook (underscore) present
+    OUTPUT: Valid one kept; underscore one moved to +meta (no clobbering)
+    WHY:    Renaming would overwrite the existing +post-hook value, so we fall back to +meta.
+    """
+    input_dict = {"+post-hook": "select 1", "+post_hook": "select 2"}
+
+    expected_output = {"+post-hook": "select 1", "+meta": {"post_hook": "select 2"}}
+
+    result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
+
+    assert result == expected_output
+    assert len(logs) == 1
     assert "post_hook" in logs[0] and "meta" in logs[0]
-    assert "pre_hook" in logs[1] and "meta" in logs[1]
 
 
 def test_mixed_valid_and_invalid_configs(models_node_fields, temp_path):
@@ -238,11 +253,12 @@ def test_multiple_unknowns_merged_into_meta(models_node_fields, temp_path):
 
 
 def test_real_world_example_user_config(models_node_fields, temp_path):
-    """INPUT:  Real user config with +post_hook (underscore - not in schema!)
-    OUTPUT: Moved to +meta.post_hook
-    WHY:    post_hook is not in schema, so treated as custom config
+    """INPUT:  Real user config with +post_hook (underscore) and a genuinely custom config
+    OUTPUT: +post_hook renamed to +post-hook; the custom config moved to +meta
+    WHY:    The hook is functional and must be preserved (renamed); the custom key is not a
+            recognized config and belongs under +meta.
 
-    NOTE: Using REAL schema - post_hook with underscore is NOT recognized
+    NOTE: Using REAL schema - post_hook underscore is normalized to the hyphenated form.
     """
     input_dict = {
         "+my_custom_unknown_config": "value",
@@ -255,12 +271,12 @@ def test_real_world_example_user_config(models_node_fields, temp_path):
 
     expected_output = {
         "+materialized": "table",
+        "+post-hook": [  # Renamed from +post_hook (functional hook preserved)
+            "{{ grant_select(this, 'data-analytics') }}",
+            "{{ grant_select(this, 'airflow_service_user_role') }}",
+        ],
         "+meta": {
-            "my_custom_unknown_config": "value",
-            "post_hook": [  # Moved to meta (not in schema)
-                "{{ grant_select(this, 'data-analytics') }}",
-                "{{ grant_select(this, 'airflow_service_user_role') }}",
-            ],
+            "my_custom_unknown_config": "value",  # Genuinely custom - moved to meta
         },
     }
 
@@ -268,8 +284,7 @@ def test_real_world_example_user_config(models_node_fields, temp_path):
 
     assert result == expected_output
     assert len(logs) == 2
-    # Both moved to meta
-    assert any("post_hook" in log and "meta" in log for log in logs)
+    assert any("+post_hook" in log and "+post-hook" in log for log in logs)
     assert any("my_custom_unknown_config" in log and "meta" in log for log in logs)
 
 
@@ -280,7 +295,7 @@ def test_all_scenarios_combined(models_node_fields, temp_path):
     """
     input_dict = {
         "+post-hook": "select 1",  # Valid, keep
-        "+pre_hook": "select 0",  # Invalid (underscore), move to meta
+        "+pre_hook": "select 0",  # Underscore hook, rename to +pre-hook
         "materialized": "table",  # Missing +, add it
         "+enabled": True,  # Valid, keep
         "+custom_unknown": "val",  # Invalid, move to meta
@@ -289,10 +304,10 @@ def test_all_scenarios_combined(models_node_fields, temp_path):
 
     expected_output = {
         "+post-hook": "select 1",
+        "+pre-hook": "select 0",  # Renamed from +pre_hook (functional hook preserved)
         "+materialized": "table",  # + added!
         "+enabled": True,
-        "+meta": {  # All invalids here
-            "pre_hook": "select 0",
+        "+meta": {  # Genuinely custom configs here
             "custom_unknown": "val",
             "another_custom": "val2",
         },
@@ -302,7 +317,7 @@ def test_all_scenarios_combined(models_node_fields, temp_path):
 
     assert result == expected_output
     assert len(logs) == 4
-    # Should have logs for: materialized +, and 3 meta moves
+    # Should have logs for: pre_hook rename, materialized +, and 2 meta moves
 
 
 # =============================================================================
@@ -344,9 +359,9 @@ def test_preserves_complex_values(models_node_fields, temp_path):
 
 
 def test_jinja_in_hook_values_preserved(models_node_fields, temp_path):
-    """INPUT:  Invalid config (+post_hook) with complex Jinja
-    OUTPUT: Moved to meta with Jinja preserved exactly
-    WHY:    We only move keys, never touch the values/Jinja content
+    """INPUT:  Underscore hook (+post_hook) with complex Jinja
+    OUTPUT: Renamed to +post-hook with Jinja preserved exactly
+    WHY:    We only change the key, never touch the values/Jinja content
     """
     input_dict = {
         "+post_hook": [
@@ -356,19 +371,17 @@ def test_jinja_in_hook_values_preserved(models_node_fields, temp_path):
     }
 
     expected_output = {
-        "+meta": {
-            "post_hook": [  # Moved to meta, values preserved exactly
-                "{%- if target.name.startswith('sf')-%}{{ grant_select(this, 'role') }}{%- endif -%}",
-                "CALL UTILS.GOVERNANCE.REAPPLY_JIRA_RESOURCE_GRANTS('{{ this | upper }}')",
-            ]
-        }
+        "+post-hook": [  # Renamed, values preserved exactly
+            "{%- if target.name.startswith('sf')-%}{{ grant_select(this, 'role') }}{%- endif -%}",
+            "CALL UTILS.GOVERNANCE.REAPPLY_JIRA_RESOURCE_GRANTS('{{ this | upper }}')",
+        ]
     }
 
     result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
 
     assert result == expected_output
     assert len(logs) == 1
-    assert "post_hook" in logs[0] and "meta" in logs[0]
+    assert "+post_hook" in logs[0] and "+post-hook" in logs[0]
 
 
 # =============================================================================
@@ -930,7 +943,8 @@ QUICK REFERENCE - What rec_check_yaml_path does:
 Input Key                  | Output Key           | Why
 ---------------------------|----------------------|----------------------------------
 +post-hook                 | +post-hook          | ✅ In schema (hyphen) - kept
-+post_hook                 | +meta.post_hook     | ❌ Not in schema - moved to meta
++post_hook                 | +post-hook          | 🔧 Underscore hook renamed to hyphen
++pre_hook                  | +pre-hook           | 🔧 Underscore hook renamed to hyphen
 post-hook                  | +post-hook          | 🔧 Added + prefix (in schema)
 +materialized              | +materialized       | ✅ In schema - kept
 materialized               | +materialized       | 🔧 Added + prefix (in schema)
@@ -939,9 +953,10 @@ materialized               | +materialized       | 🔧 Added + prefix (in schem
 custom_config              | +meta.custom_config | ❌ Not in schema - moved to meta
 
 Key insights:
-1. Only checks if key is IN SCHEMA - no spelling correction
-2. dbt_project.yml schema expects: +pre-hook, +post-hook (hyphens)
+1. dbt_project.yml schema expects hyphenated hooks: +pre-hook, +post-hook
+2. Underscore hook forms (+pre_hook/+post_hook) are renamed to the hyphenated form,
+   not moved to +meta, so functional hooks are preserved
 3. All configs need + prefix in dbt_project.yml
-4. Any config NOT in schema → moved to +meta
+4. Any other config NOT in schema → moved to +meta
 5. 🎯 Tests use REAL Fusion schema - accurate validation!
 """


### PR DESCRIPTION
## What & why

In `dbt_project.yml`, project-level `+pre_hook` / `+post_hook` (underscore) were being moved to `+meta` instead of renamed to the hyphenated `+pre-hook` / `+post-hook`. Because dbt-core accepts the underscore alias and **runs** the hook, this silently disabled a functional hook — the SQL stays in the project but under `meta` it never executes.

This surfaced as a Fusion conformance `dbt1405` SQL mismatch: dbt-core runs the hook (recording contains the hook SQL), but Fusion on the autofixed project never emits it, shifting the replay cursor so an unrelated statement (e.g. a `comment on view`) is compared against the recorded hook SQL.

### Behavior across engines (validated on duckdb)

| Engine | `+pre_hook` (underscore) in `dbt_project.yml` |
| --- | --- |
| dbt-core | Accepts the alias, **runs** the hook |
| Fusion | **Rejects** it (`dbt1013`); only `+pre-hook` is valid |
| dbt-autofix (before) | Moves to `+meta.pre_hook` → hook never runs, no error/warning |

## Root cause

Fusion's `dbt_project.yml` schema declares the hyphenated `+pre-hook`/`+post-hook`, so `allowed_config_fields_dbt_project` contains `pre-hook`, not `pre_hook`. `rec_check_yaml_path` moved any `+`-key not in that set to `+meta`, and — unlike the schema.yml / SQL paths (`COMMON_CONFIG_MISSPELLINGS`, hyphen→underscore for the node-level canonical) — the `dbt_project.yml` path had no normalization for the project-level direction.

## Change

- Add `DBT_PROJECT_CONFIG_MISSPELLINGS = {"pre_hook": "pre-hook", "post_hook": "post-hook"}`.
- In `rec_check_yaml_path`, rename the underscore hook forms to the hyphenated `+`-prefixed form **before** the move-to-`+meta` fallback (covers `+pre_hook` and bare `pre_hook`), guarded so it won't clobber an existing `+pre-hook`/`+post-hook`.
- Update/added unit tests; refreshed the quick-reference doc.

After the fix:
```
Renamed config '+pre_hook' to '+pre-hook' (dbt_project.yml expects the hyphenated hook form)
```
and the fixed project parses in Fusion with the hook executing.

Node-level `config(pre_hook=...)` / schema.yml `config:` are unaffected.

## Testing

- `tests/unit_tests/test_rec_check_yaml_path.py` (42), plus `test_config_meta_autofix.py` / `test_refactor.py` / `test_dict_config_subkeys.py` / `test_fix_space_after_plus.py` (154) and integration tests (7) — all green.
- End-to-end: ran dbt-autofix on a repro, then confirmed the pre-hook runs in Fusion and in dbt-core (via `uv run --with dbt-duckdb`).

Fixes #396
