### PR TITLE
Output installed package versions from package lock file

### DIFF
--- a/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/upgrade_status.py
+++ b/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/upgrade_status.py
@@ -35,4 +35,5 @@ class PackageVersionUpgradeType(str, Enum):
         "Public package has Fusion-compatible version that is outside the project's requested version range"
     )
     PRIVATE_PACKAGE_MISSING_REQUIRE_DBT_VERSION = "Private package requires a compatible require-dbt-version (>=2.0.0, <3.0.0) to be available on Fusion. https://docs.getdbt.com/reference/project-configs/require-dbt-version"
+    TRANSITIVE_DEPENDENCY = "Package is a transitive dependency of another package in your project"
     UNKNOWN = "Package's Fusion eligibility unknown"

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -80,8 +80,10 @@ class PackageVersionUpgradeResult:
 
     def to_dict(self) -> dict:
         ret_dict = {"id": self.id, "version": self.package_final_version(), "log": self.package_upgrade_logs}
+        # output if we determined a canonical installed version from the package lock file
         if self.package_lock_version_found and self.installed_version != "unknown":
             ret_dict["original_version"] = self.installed_version
+        # separately log the upgraded version for convenience
         if (self.package_should_upgrade() or self.upgraded) and self.upgraded_version:
             ret_dict["upgraded_version"] = self.upgraded_version
         return ret_dict
@@ -423,7 +425,8 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                 )
             )
 
-    # if we have derived transitive dependencies from a lock file, output those as unchanged
+    # if we have derived transitive dependencies from a lock file, can't upgrade those packages
+    # but still display their compatibility information for reference
     if deps_file.has_lock_file and len(deps_file.transitive_dependencies) > 0:
         packages_already_checked: set[str] = set([x.id for x in package_version_upgrade_results])
         for version in deps_file.transitive_dependencies:

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -43,6 +43,7 @@ class PackageVersionUpgradeResult:
     compatible_version: Optional[str] = None
     version_range_config: Optional[str] = None
     upgraded: bool = False
+    package_lock_version_found: bool = False
 
     def package_should_upgrade(self):
         return self.version_reason == PackageVersionUpgradeType.UPGRADE_AVAILABLE
@@ -58,15 +59,20 @@ class PackageVersionUpgradeResult:
     @property
     def package_upgrade_logs(self):
         logs: list[str] = [self.version_reason.value]
+        current_version_text: str = (
+            f"Current version ({self.installed_version})"
+            if self.package_lock_version_found and self.installed_version != "unknown"
+            else "Current version"
+        )
         if self.already_compatible:
             current_version_compat = (
-                f"Current version is compatible: {self.installed_version_compatibility_state.value}"
+                f"{current_version_text} is compatible: {self.installed_version_compatibility_state.value}"
             )
         elif self.installed_version_compatibility_state == PackageVersionFusionCompatibilityState.UNKNOWN:
-            current_version_compat = "Current version compatibility unknown"
+            current_version_compat = f"{current_version_text} compatibility unknown"
         else:
             current_version_compat = (
-                f"Current version is not compatible: {self.installed_version_compatibility_state.value}"
+                f"{current_version_text} is not compatible: {self.installed_version_compatibility_state.value}"
             )
         logs.append(current_version_compat)
         if self.upgraded and self.upgraded_version and self.upgraded_version_compatibility_state is not None:
@@ -79,6 +85,8 @@ class PackageVersionUpgradeResult:
 
     def to_dict(self) -> dict:
         ret_dict = {"id": self.id, "version": self.package_final_version(), "log": self.package_upgrade_logs}
+        if self.package_lock_version_found and self.installed_version != "unknown":
+            ret_dict["installed_version"] = self.installed_version
         return ret_dict
 
 
@@ -180,6 +188,8 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
     # check all packages for upgrades
     # if dry run, write out package upgrades and exit
     package_version_upgrade_results: list[PackageVersionUpgradeResult] = []
+    # flag if we found a package lock file
+    has_package_lock_file: bool = deps_file.has_lock_file
 
     # create a set of all packages in file - packages will be removed once checked
     packages_to_check: set[str] = set([package for package in deps_file.package_dependencies])
@@ -230,6 +240,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.NO_UPGRADE_REQUIRED,
                     installed_version_compatibility_state=installed_version_compat,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -244,6 +255,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.PRIVATE_PACKAGE_MISSING_REQUIRE_DBT_VERSION,
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.UNKNOWN,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -262,6 +274,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.NO_UPGRADE_REQUIRED,
                     installed_version_compatibility_state=installed_version_compat,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -277,6 +290,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.NO_UPGRADE_REQUIRED,
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -291,6 +305,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.PUBLIC_PACKAGE_NOT_COMPATIBLE_WITH_FUSION,
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_EXCLUDES_2_0,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -305,6 +320,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.PUBLIC_PACKAGE_MISSING_FUSION_ELIGIBILITY,
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.UNKNOWN,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -355,6 +371,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     upgraded_version_compatibility_state=PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW
                     if package in EXPLICIT_ALLOW_ALL_VERSIONS
                     else PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_INCLUDES_2_0,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -372,6 +389,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     upgraded_version_compatibility_state=PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW
                     if package in EXPLICIT_ALLOW_ALL_VERSIONS
                     else PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_INCLUDES_2_0,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -387,6 +405,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.PUBLIC_PACKAGE_NOT_COMPATIBLE_WITH_FUSION,
                     installed_version_compatibility_state=installed_version_compat,
                     upgraded_version_compatibility_state=PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_EXCLUDES_2_0,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
             packages_to_check.remove(package)
@@ -403,6 +422,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     version_reason=PackageVersionUpgradeType.PUBLIC_PACKAGE_MISSING_FUSION_ELIGIBILITY,
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.UNKNOWN,
                     upgraded_version_compatibility_state=None,
+                    package_lock_version_found=has_package_lock_file,
                 )
             )
     return package_version_upgrade_results
@@ -466,7 +486,7 @@ def upgrade_package_versions(
 
     package_text_file = DbtPackageTextFile(file_path=deps_file.file_path)
     updated_packages: set[str] = package_text_file.update_config_file(
-        packages_to_update, dry_run=dry_run, print_to_console=True
+        packages_to_update, dry_run=dry_run, print_to_console=(not json_output)
     )
 
     upgraded_package_results: list[PackageVersionUpgradeResult] = []

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -59,20 +59,15 @@ class PackageVersionUpgradeResult:
     @property
     def package_upgrade_logs(self):
         logs: list[str] = [self.version_reason.value]
-        current_version_text: str = (
-            f"Current version ({self.installed_version})"
-            if self.package_lock_version_found and self.installed_version != "unknown"
-            else "Current version"
-        )
         if self.already_compatible:
             current_version_compat = (
-                f"{current_version_text} is compatible: {self.installed_version_compatibility_state.value}"
+                f"Current version is compatible: {self.installed_version_compatibility_state.value}"
             )
         elif self.installed_version_compatibility_state == PackageVersionFusionCompatibilityState.UNKNOWN:
-            current_version_compat = f"{current_version_text} compatibility unknown"
+            current_version_compat = "Current version compatibility unknown"
         else:
             current_version_compat = (
-                f"{current_version_text} is not compatible: {self.installed_version_compatibility_state.value}"
+                f"Current version is not compatible: {self.installed_version_compatibility_state.value}"
             )
         logs.append(current_version_compat)
         if self.upgraded and self.upgraded_version and self.upgraded_version_compatibility_state is not None:
@@ -86,7 +81,9 @@ class PackageVersionUpgradeResult:
     def to_dict(self) -> dict:
         ret_dict = {"id": self.id, "version": self.package_final_version(), "log": self.package_upgrade_logs}
         if self.package_lock_version_found and self.installed_version != "unknown":
-            ret_dict["installed_version"] = self.installed_version
+            ret_dict["original_version"] = self.installed_version
+        if (self.package_should_upgrade() or self.upgraded) and self.upgraded_version:
+            ret_dict["upgraded_version"] = self.upgraded_version
         return ret_dict
 
 
@@ -425,6 +422,29 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     package_lock_version_found=has_package_lock_file,
                 )
             )
+
+    # if we have derived transitive dependencies from a lock file, output those as unchanged
+    if deps_file.has_lock_file and len(deps_file.transitive_dependencies) > 0:
+        packages_already_checked: set[str] = set([x.id for x in package_version_upgrade_results])
+        for version in deps_file.transitive_dependencies:
+            if version not in packages_already_checked:
+                transitive_dependency_version: DbtPackageVersion = deps_file.transitive_dependencies[version]
+                transitive_dependency_compatibility: PackageVersionFusionCompatibilityState = (
+                    transitive_dependency_version.get_fusion_compatibility_state()
+                )
+                package_version_upgrade_results.append(
+                    PackageVersionUpgradeResult(
+                        id=version,
+                        public_package=True,
+                        installed_version=transitive_dependency_version.package_version_str,
+                        version_reason=PackageVersionUpgradeType.TRANSITIVE_DEPENDENCY,
+                        installed_version_compatibility_state=transitive_dependency_compatibility,
+                        upgraded_version_compatibility_state=None,
+                        upgraded=False,
+                        package_lock_version_found=True,
+                    )
+                )
+
     return package_version_upgrade_results
 
 

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -118,6 +118,8 @@ class DbtPackageFile:
     package_dependencies: dict[str, DbtPackage] = field(default_factory=dict)
     transitive_dependencies: dict[str, DbtPackageVersion] = field(default_factory=dict)
     unknown_packages: set[str] = field(default_factory=set)
+    # track if the project has a package-lock.yml so we can determine canonical versions
+    has_lock_file: bool = False
 
     def parse_file_path_to_string(self):
         if not self.file_path:
@@ -157,6 +159,7 @@ class DbtPackageFile:
         return self.package_dependencies[package_id].add_package_version(package_version, installed=installed)
 
     def merge_package_lock_versions(self, lock_file: DbtPackageLockFile) -> int:
+        self.has_lock_file = True
         package_lock_found_in_deps: int = 0
         for lock_file_package in lock_file.installed_package_versions:
             lock_package_id: Optional[str] = lock_file.installed_package_versions[lock_file_package].package_id

--- a/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
+++ b/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
@@ -105,7 +105,9 @@ def test_upgrade_package_versions_no_force_update():
     assert not output.upgraded
     assert len(output.upgrades) == 0
     assert len(output.unchanged) == 3 + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
-    assert len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
+    assert (
+        len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
+    )
     output.print_to_console(json_output=False)
     output.print_to_console(json_output=True)
 
@@ -122,6 +124,8 @@ def test_upgrade_package_versions_with_force_update():
     assert output.upgraded
     assert len(output.upgrades) == 1
     assert len(output.unchanged) == 2 + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
-    assert len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
+    assert (
+        len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
+    )
     output.print_to_console(json_output=False)
     output.print_to_console(json_output=True)

--- a/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
+++ b/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
@@ -79,7 +79,7 @@ def test_check_for_package_upgrades():
     package_file: Optional[DbtPackageFile] = generate_package_dependencies(PROJECT_WITH_PACKAGE_LOCK_PATH)
     assert package_file is not None
     output: list[PackageVersionUpgradeResult] = check_for_package_upgrades(package_file)
-    assert len(output) == PROJECT_DEPENDENCY_COUNT
+    assert len(output) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
     for package_result in output:
         print(f"test output: {package_result.id}, {package_result.version_reason}")
         package = package_result.id
@@ -104,8 +104,8 @@ def test_upgrade_package_versions_no_force_update():
     assert output
     assert not output.upgraded
     assert len(output.upgrades) == 0
-    assert len(output.unchanged) == 3
-    assert len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT
+    assert len(output.unchanged) == 3 + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
+    assert len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
     output.print_to_console(json_output=False)
     output.print_to_console(json_output=True)
 
@@ -121,7 +121,7 @@ def test_upgrade_package_versions_with_force_update():
     assert output
     assert output.upgraded
     assert len(output.upgrades) == 1
-    assert len(output.unchanged) == 2
-    assert len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT
+    assert len(output.unchanged) == 2 + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
+    assert len(output.upgrades) + len(output.unchanged) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
     output.print_to_console(json_output=False)
     output.print_to_console(json_output=True)

--- a/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
+++ b/tests/unit_tests/package_upgrades/test_package_upgrade_with_lock_file.py
@@ -97,7 +97,7 @@ def test_upgrade_package_versions_no_force_update():
     package_file: Optional[DbtPackageFile] = generate_package_dependencies(PROJECT_WITH_PACKAGE_LOCK_PATH)
     assert package_file is not None
     upgrades: list[PackageVersionUpgradeResult] = check_for_package_upgrades(package_file)
-    assert len(upgrades) == PROJECT_DEPENDENCY_COUNT
+    assert len(upgrades) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
     output: PackageUpgradeResult = upgrade_package_versions(
         package_file, upgrades, dry_run=True, override_pinned_version=False
     )
@@ -114,7 +114,7 @@ def test_upgrade_package_versions_with_force_update():
     package_file: Optional[DbtPackageFile] = generate_package_dependencies(PROJECT_WITH_PACKAGE_LOCK_PATH)
     assert package_file is not None
     upgrades: list[PackageVersionUpgradeResult] = check_for_package_upgrades(package_file)
-    assert len(upgrades) == PROJECT_DEPENDENCY_COUNT
+    assert len(upgrades) == PROJECT_DEPENDENCY_COUNT + PROJECT_TRANSITIVE_DEPENDENCY_COUNT
     output: PackageUpgradeResult = upgrade_package_versions(
         package_file, upgrades, dry_run=True, override_pinned_version=True
     )


### PR DESCRIPTION
## Description

This change outputs the canonical installed package version from the package-lock.yml (if available). It also outputs compatibility information for transitive dependencies that can't be upgraded by autofix.

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
