### PR TITLE
Enable fixing of static_analysis values from dbt-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following deprecations are covered by `dbt-autofix deprecations`:
 | `ResourceNamesWithSpacesDeprecation` | SQL files, Python files, YAML files | Replaces spaces with underscores in resource names, updating .sql filenames as necessary | Full | Yes |  
 | `SourceFreshnessProjectHooksNotRun` | `dbt_project.yml` | Set `source_freshness_run_project_hooks` in `dbt_project.yml` "flags" to true | Full | Yes |
 | `MissingArgumentsPropertyInGenericTestDeprecation` | YAML files | Move any keyword arguments defined as top-level property on generic test to `arguments` property | Full | No |
+| `StaticAnalysisDeprecation` | `dbt_project.yml`, YAML files, SQL files | Convert boolean `static_analysis` values to the Fusion enum (`True`→`baseline`, `False`→`off`) | Full | No |
 
 ## Deprecation Coverage - CLI Commands
 

--- a/src/dbt_autofix/refactor.py
+++ b/src/dbt_autofix/refactor.py
@@ -40,6 +40,7 @@ from dbt_autofix.refactors.changesets.dbt_schema_yml_semantic_layer import (
 )
 from dbt_autofix.refactors.changesets.dbt_sql import (
     refactor_custom_configs_to_meta_sql,
+    refactor_static_analysis_sql,
     remove_unmatched_endings,
     rename_sql_file_names_with_spaces,
 )
@@ -54,6 +55,9 @@ from dbt_autofix.refactors.results import (
     SQLRefactorResult,
     YMLRefactorConfig,
     YMLRefactorResult,
+)
+from dbt_autofix.refactors.static_analysis import (
+    changeset_normalize_static_analysis_yml,
 )
 from dbt_autofix.refactors.yml import load_yaml
 from dbt_autofix.retrieve_schemas import (
@@ -106,6 +110,7 @@ def process_yaml_files_except_dbt_project(
         changeset_remove_duplicate_models,
         changeset_refactor_yml_str,
         changeset_owner_properties_yml_str,
+        changeset_normalize_static_analysis_yml,
     ]
     all_rules: List[Callable] = [*safe_change_rules, *behavior_change_rules]
     changesets = all_rules if all else behavior_change_rules if behavior_change else safe_change_rules
@@ -236,6 +241,7 @@ def process_dbt_project_yml(
         changeset_dbt_project_remove_deprecated_config,
         changeset_fix_space_after_plus,
         changeset_dbt_project_prefix_plus_for_config,
+        changeset_normalize_static_analysis_yml,
     ]
     all_rules = [*behavior_change_rules, *safe_change_rules]
 
@@ -283,6 +289,7 @@ def process_sql_files(
     safe_change_rules: List[Callable] = [
         remove_unmatched_endings,
         refactor_custom_configs_to_meta_sql,
+        refactor_static_analysis_sql,
         move_custom_config_access_to_meta_sql_improved,
     ]
     all_rules = [*behavior_change_rules, *safe_change_rules]

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -406,7 +406,9 @@ def _iter_config_macro_spans(sql_content: str) -> List[Tuple[int, int, str]]:
     return spans
 
 
-def refactor_static_analysis_sql(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
+def refactor_static_analysis_sql(
+    content: SQLContent, config: Optional[SQLRefactorConfig] = None
+) -> SQLRuleRefactorResult:
     """Normalize boolean ``static_analysis`` values in SQL ``{{ config(...) }}`` calls.
 
     Converts ``static_analysis=True`` -> ``static_analysis='baseline'`` and

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -6,6 +6,11 @@ from dbt_autofix.deprecations import DeprecationType
 from dbt_autofix.jinja import statically_parse_unrendered_config
 from dbt_autofix.refactors.constants import COMMON_CONFIG_MISSPELLINGS
 from dbt_autofix.refactors.results import DbtDeprecationRefactor, SQLContent, SQLRefactorConfig, SQLRuleRefactorResult
+from dbt_autofix.refactors.static_analysis import (
+    STATIC_ANALYSIS_DEPRECATION,
+    STATIC_ANALYSIS_KEY,
+    normalize_static_analysis_source,
+)
 
 CONFIG_MACRO_PATTERN = re.compile(r"(\{\{\s*config\s*\()(.*?)(\)\s*\}\})", re.DOTALL)
 
@@ -376,6 +381,85 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
         original_content=sql_content,
         deprecation_refactors=deprecation_refactors,
         refactor_warnings=refactor_warnings,
+    )
+
+
+def _iter_config_macro_spans(sql_content: str) -> List[Tuple[int, int, str]]:
+    """Return ``(start, end, macro_str)`` for every ``{{ config(...) }}`` call in the content.
+
+    Iterating over all calls (rather than just the first) means a ``{{ config() }}`` that
+    appears in a comment ahead of the real config block doesn't shadow it.
+    """
+    spans: List[Tuple[int, int, str]] = []
+    pos = 0
+    while True:
+        match = re.search(r"\{\{\s*config\s*\(", sql_content[pos:])
+        if not match:
+            break
+        abs_start = pos + match.start()
+        macro = extract_config_macro(sql_content[abs_start:])
+        if macro is None:
+            pos = abs_start + match.end() - match.start()
+            continue
+        spans.append((abs_start, abs_start + len(macro), macro))
+        pos = abs_start + len(macro)
+    return spans
+
+
+def refactor_static_analysis_sql(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
+    """Normalize boolean ``static_analysis`` values in SQL ``{{ config(...) }}`` calls.
+
+    Converts ``static_analysis=True`` -> ``static_analysis='baseline'`` and
+    ``static_analysis=False`` -> ``static_analysis='off'`` so Fusion can load the project.
+    Already-valid enum values are left untouched.
+    """
+    sql_content = content.current_str
+    deprecation_refactors: List[DbtDeprecationRefactor] = []
+
+    if "config(" not in sql_content:
+        return SQLRuleRefactorResult(
+            rule_name="normalize_static_analysis_sql",
+            refactored=False,
+            refactored_content=sql_content,
+            original_content=sql_content,
+            deprecation_refactors=[],
+        )
+
+    refactored_content = sql_content
+    # Process macros from last to first so earlier spans keep their positions after splicing.
+    for start, end, macro_str in reversed(_iter_config_macro_spans(sql_content)):
+        parsed_config = statically_parse_unrendered_config(macro_str)
+        if not parsed_config or STATIC_ANALYSIS_KEY not in parsed_config:
+            continue
+
+        original_source = parsed_config[STATIC_ANALYSIS_KEY]
+        new_enum = normalize_static_analysis_source(str(original_source))
+        if new_enum is None:
+            continue
+
+        # Preserve every other config value verbatim via the source map, overriding only static_analysis.
+        config_source_map = dict(parsed_config)
+        config_source_map[STATIC_ANALYSIS_KEY] = f"'{new_enum}'"
+
+        new_config_str = _serialize_config_macro_call(parsed_config, config_source_map)
+        new_macro = f"{{{{ config({new_config_str}\n) }}}}"
+        refactored_content = refactored_content[:start] + new_macro + refactored_content[end:]
+
+        deprecation_refactors.insert(
+            0,
+            DbtDeprecationRefactor(
+                log=f"Converted static_analysis={original_source} to static_analysis='{new_enum}' "
+                "(static_analysis must be a Fusion enum value)",
+                deprecation=STATIC_ANALYSIS_DEPRECATION,
+            ),
+        )
+
+    return SQLRuleRefactorResult(
+        rule_name="normalize_static_analysis_sql",
+        refactored=refactored_content != sql_content,
+        refactored_content=refactored_content,
+        original_content=sql_content,
+        deprecation_refactors=deprecation_refactors,
     )
 
 

--- a/src/dbt_autofix/refactors/static_analysis.py
+++ b/src/dbt_autofix/refactors/static_analysis.py
@@ -1,0 +1,127 @@
+"""Normalize legacy boolean ``static_analysis`` config values to the Fusion enum.
+
+The dbt platform / Fusion engine expects ``static_analysis`` to be one of the string
+enum values ``unsafe | off | strict | baseline | on``. Older projects set it to a
+boolean (``True``/``False``) or a truthy/falsy spelling (``yes``/``no``), which makes
+Fusion fail to load the project manifest with ``dbt1150``:
+
+    unknown variant `False`, expected one of `unsafe`, `off`, `strict`, `baseline`, `on`
+
+This module converts those legacy values to the enum equivalents:
+
+    True  / true / yes  -> 'baseline'
+    False / false / no  -> 'off'
+
+Values that are already valid enum members (``on``, ``off``, ``baseline``, ``strict``,
+``unsafe``) are left untouched, and so is anything else we don't recognize.
+"""
+
+from typing import List, Optional, Tuple
+
+from ruamel.yaml.scalarstring import SingleQuotedScalarString
+
+from dbt_autofix.refactors.results import DbtDeprecationRefactor, YMLContent, YMLRuleRefactorResult
+from dbt_autofix.refactors.yml import DbtYAML, load_yaml
+
+STATIC_ANALYSIS_KEY = "static_analysis"
+STATIC_ANALYSIS_DEPRECATION = "StaticAnalysisDeprecation"
+
+# Already-valid Fusion enum values - never converted.
+VALID_STATIC_ANALYSIS_ENUM = {"unsafe", "off", "strict", "baseline", "on"}
+
+# Legacy spellings that map onto the enum. Note that ``on``/``off`` are intentionally
+# absent here: they are already valid enum members and must be preserved as-is.
+_TRUTHY_SPELLINGS = {"true", "yes"}
+_FALSY_SPELLINGS = {"false", "no"}
+
+
+def normalize_static_analysis_value(value: object) -> Optional[str]:
+    """Return the enum string a ``static_analysis`` value should become, or ``None``.
+
+    ``None`` means the value is already valid (or is something we don't touch) and
+    should be left unchanged. Accepts values as parsed from YAML (bool or str).
+    """
+    if isinstance(value, bool):
+        return "baseline" if value else "off"
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in _TRUTHY_SPELLINGS:
+            return "baseline"
+        if lowered in _FALSY_SPELLINGS:
+            return "off"
+    return None
+
+
+def normalize_static_analysis_source(source: str) -> Optional[str]:
+    """Return the enum string for a ``static_analysis`` value written in a SQL ``config()`` call.
+
+    The value arrives as source code (e.g. ``True``, ``'baseline'``). Returns the bare
+    enum string (unquoted) to convert to, or ``None`` to leave the value unchanged.
+    """
+    stripped = source.strip()
+    # Unwrap a quoted string literal so we compare against the inner value.
+    if len(stripped) > 1 and stripped[0] in ("'", '"') and stripped[-1] == stripped[0]:
+        inner = stripped[1:-1]
+    else:
+        inner = stripped
+    lowered = inner.strip().lower()
+    if lowered in _TRUTHY_SPELLINGS:
+        return "baseline"
+    if lowered in _FALSY_SPELLINGS:
+        return "off"
+    return None
+
+
+def _normalize_in_place(node: object, changes: List[Tuple[str, object, str]]) -> None:
+    """Recursively walk a parsed YAML structure, normalizing ``static_analysis`` values.
+
+    Mutates ``node`` in place and appends ``(key, old_value, new_value)`` tuples to
+    ``changes`` for each conversion performed. Handles both the plain key
+    (``static_analysis``, used in schema.yml and at the top level of dbt_project.yml)
+    and the ``+``-prefixed key (``+static_analysis``, used under node blocks in
+    dbt_project.yml).
+    """
+    if isinstance(node, dict):
+        for key in list(node.keys()):
+            value = node[key]
+            key_name = key[1:] if isinstance(key, str) and key.startswith("+") else key
+            if key_name == STATIC_ANALYSIS_KEY and not isinstance(value, (dict, list)):
+                normalized = normalize_static_analysis_value(value)
+                if normalized is not None:
+                    node[key] = SingleQuotedScalarString(normalized)
+                    changes.append((str(key), value, normalized))
+                continue
+            _normalize_in_place(value, changes)
+    elif isinstance(node, list):
+        for item in node:
+            _normalize_in_place(item, changes)
+
+
+def changeset_normalize_static_analysis_yml(content: YMLContent, config: object) -> YMLRuleRefactorResult:
+    """Normalize boolean ``static_analysis`` config values to the Fusion enum in a YAML file.
+
+    Works for both ``dbt_project.yml`` (top-level and ``+static_analysis`` under node
+    blocks) and schema YAML ``config:`` blocks (model/seed/snapshot/source levels).
+    """
+    yml_str = content.current_str
+    yml_dict = load_yaml(yml_str)
+
+    changes: List[Tuple[str, object, str]] = []
+    _normalize_in_place(yml_dict, changes)
+
+    deprecation_refactors = [
+        DbtDeprecationRefactor(
+            log=f"Converted '{key}: {old_value}' to '{key}: {new_value}' (static_analysis must be a Fusion enum value)",
+            deprecation=STATIC_ANALYSIS_DEPRECATION,
+        )
+        for key, old_value, new_value in changes
+    ]
+
+    refactored = len(deprecation_refactors) > 0
+    return YMLRuleRefactorResult(
+        rule_name="normalize_static_analysis",
+        refactored=refactored,
+        refactored_yaml=DbtYAML().dump_to_string(yml_dict) if refactored else yml_str,
+        original_yaml=yml_str,
+        deprecation_refactors=deprecation_refactors,
+    )

--- a/src/dbt_autofix/refactors/static_analysis.py
+++ b/src/dbt_autofix/refactors/static_analysis.py
@@ -16,7 +16,7 @@ Values that are already valid enum members (``on``, ``off``, ``baseline``, ``str
 ``unsafe``) are left untouched, and so is anything else we don't recognize.
 """
 
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from ruamel.yaml.scalarstring import SingleQuotedScalarString
 
@@ -72,7 +72,7 @@ def normalize_static_analysis_source(source: str) -> Optional[str]:
     return None
 
 
-def _normalize_in_place(node: object, changes: List[Tuple[str, object, str]]) -> None:
+def _normalize_in_place(node: Any, changes: List[Tuple[str, Any, str]]) -> None:
     """Recursively walk a parsed YAML structure, normalizing ``static_analysis`` values.
 
     Mutates ``node`` in place and appends ``(key, old_value, new_value)`` tuples to
@@ -106,7 +106,7 @@ def changeset_normalize_static_analysis_yml(content: YMLContent, config: object)
     yml_str = content.current_str
     yml_dict = load_yaml(yml_str)
 
-    changes: List[Tuple[str, object, str]] = []
+    changes: List[Tuple[str, Any, str]] = []
     _normalize_in_place(yml_dict, changes)
 
     deprecation_refactors = [

--- a/tests/integration_tests/dbt_projects/project_static_analysis/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_static_analysis/dbt_project.yml
@@ -1,0 +1,28 @@
+name: 'project_static_analysis'
+version: '1.0.0'
+profile: 'test'
+
+# top-level boolean True -> 'baseline'
+static_analysis: True
+
+models:
+  project_static_analysis:
+    # +static_analysis boolean False -> 'off'
+    +static_analysis: False
+    staging:
+      +static_analysis: yes
+    legacy:
+      +static_analysis: no
+    # already-valid enum values are left untouched
+    valid_zone:
+      +static_analysis: baseline
+    off_zone:
+      +static_analysis: off
+
+seeds:
+  project_static_analysis:
+    +static_analysis: True
+
+snapshots:
+  project_static_analysis:
+    +static_analysis: False

--- a/tests/integration_tests/dbt_projects/project_static_analysis/models/model_sql_false.sql
+++ b/tests/integration_tests/dbt_projects/project_static_analysis/models/model_sql_false.sql
@@ -1,0 +1,6 @@
+{{ config(
+    materialized='view',
+    static_analysis=False
+) }}
+
+select 2 as id

--- a/tests/integration_tests/dbt_projects/project_static_analysis/models/model_sql_true.sql
+++ b/tests/integration_tests/dbt_projects/project_static_analysis/models/model_sql_true.sql
@@ -1,0 +1,6 @@
+{{ config(
+    materialized='table',
+    static_analysis=True
+) }}
+
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_static_analysis/models/schema.yml
+++ b/tests/integration_tests/dbt_projects/project_static_analysis/models/schema.yml
@@ -1,0 +1,15 @@
+version: 2
+
+models:
+  - name: model_sql_true
+    config:
+      static_analysis: True
+  - name: model_sql_false
+    config:
+      static_analysis: False
+  - name: model_yaml_yes
+    config:
+      static_analysis: yes
+  - name: model_already_valid
+    config:
+      static_analysis: baseline

--- a/tests/integration_tests/dbt_projects/project_static_analysis/seeds/sample_seed.csv
+++ b/tests/integration_tests/dbt_projects/project_static_analysis/seeds/sample_seed.csv
@@ -1,0 +1,3 @@
+id,name
+1,foo
+2,bar

--- a/tests/integration_tests/dbt_projects/project_static_analysis_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project_static_analysis_expected.stdout
@@ -1,0 +1,79 @@
+[
+  {
+    "mode": "complete"
+  },
+  {
+    "file_path": "project_static_analysis/dbt_project.yml",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "MissingGenericTestArgumentsPropertyDeprecation",
+        "log": "Set flag 'require_generic_test_arguments_property' to 'True' - This will parse the values defined within the `arguments` property of test definition as the test keyword arguments."
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted 'static_analysis: True' to 'static_analysis: baseline' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted '+static_analysis: False' to '+static_analysis: off' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted '+static_analysis: yes' to '+static_analysis: baseline' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted '+static_analysis: no' to '+static_analysis: off' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted '+static_analysis: True' to '+static_analysis: baseline' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted '+static_analysis: False' to '+static_analysis: off' (static_analysis must be a Fusion enum value)"
+      }
+    ]
+  },
+  {
+    "file_path": "project_static_analysis/models/model_sql_false.sql",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted static_analysis=False to static_analysis='off' (static_analysis must be a Fusion enum value)"
+      }
+    ],
+    "warnings": []
+  },
+  {
+    "file_path": "project_static_analysis/models/model_sql_true.sql",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted static_analysis=True to static_analysis='baseline' (static_analysis must be a Fusion enum value)"
+      }
+    ],
+    "warnings": []
+  },
+  {
+    "file_path": "project_static_analysis/models/schema.yml",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted 'static_analysis: True' to 'static_analysis: baseline' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted 'static_analysis: False' to 'static_analysis: off' (static_analysis must be a Fusion enum value)"
+      },
+      {
+        "deprecation": "StaticAnalysisDeprecation",
+        "log": "Converted 'static_analysis: yes' to 'static_analysis: baseline' (static_analysis must be a Fusion enum value)"
+      }
+    ]
+  }
+]

--- a/tests/integration_tests/dbt_projects/project_static_analysis_expected/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_static_analysis_expected/dbt_project.yml
@@ -1,0 +1,30 @@
+name: 'project_static_analysis'
+version: '1.0.0'
+profile: 'test'
+
+# top-level boolean True -> 'baseline'
+static_analysis: 'baseline'
+
+models:
+  project_static_analysis:
+    # +static_analysis boolean False -> 'off'
+    +static_analysis: 'off'
+    staging:
+      +static_analysis: 'baseline'
+    legacy:
+      +static_analysis: 'off'
+    # already-valid enum values are left untouched
+    valid_zone:
+      +static_analysis: baseline
+    off_zone:
+      +static_analysis: off
+
+seeds:
+  project_static_analysis:
+    +static_analysis: 'baseline'
+
+snapshots:
+  project_static_analysis:
+    +static_analysis: 'off'
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_static_analysis_expected/models/model_sql_false.sql
+++ b/tests/integration_tests/dbt_projects/project_static_analysis_expected/models/model_sql_false.sql
@@ -1,0 +1,6 @@
+{{ config(
+    materialized='view', 
+    static_analysis='off'
+) }}
+
+select 2 as id

--- a/tests/integration_tests/dbt_projects/project_static_analysis_expected/models/model_sql_true.sql
+++ b/tests/integration_tests/dbt_projects/project_static_analysis_expected/models/model_sql_true.sql
@@ -1,0 +1,6 @@
+{{ config(
+    materialized='table', 
+    static_analysis='baseline'
+) }}
+
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_static_analysis_expected/models/schema.yml
+++ b/tests/integration_tests/dbt_projects/project_static_analysis_expected/models/schema.yml
@@ -1,0 +1,15 @@
+version: 2
+
+models:
+  - name: model_sql_true
+    config:
+      static_analysis: 'baseline'
+  - name: model_sql_false
+    config:
+      static_analysis: 'off'
+  - name: model_yaml_yes
+    config:
+      static_analysis: 'baseline'
+  - name: model_already_valid
+    config:
+      static_analysis: baseline

--- a/tests/integration_tests/dbt_projects/project_static_analysis_expected/seeds/sample_seed.csv
+++ b/tests/integration_tests/dbt_projects/project_static_analysis_expected/seeds/sample_seed.csv
@@ -1,0 +1,3 @@
+id,name
+1,foo
+2,bar

--- a/tests/unit_tests/test_static_analysis.py
+++ b/tests/unit_tests/test_static_analysis.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+
+import pytest
+
+from dbt_autofix.refactors.changesets.dbt_sql import refactor_static_analysis_sql
+from dbt_autofix.refactors.results import SQLContent, YMLContent
+from dbt_autofix.refactors.static_analysis import (
+    changeset_normalize_static_analysis_yml,
+    normalize_static_analysis_source,
+    normalize_static_analysis_value,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "baseline"),
+        (False, "off"),
+        ("true", "baseline"),
+        ("True", "baseline"),
+        ("yes", "baseline"),
+        ("YES", "baseline"),
+        ("false", "off"),
+        ("no", "off"),
+        # Already-valid enum values are left untouched.
+        ("baseline", None),
+        ("off", None),
+        ("on", None),
+        ("strict", None),
+        ("unsafe", None),
+        # Unrelated values are left untouched.
+        (42, None),
+        ("something_else", None),
+    ],
+)
+def test_normalize_static_analysis_value(value, expected):
+    assert normalize_static_analysis_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("True", "baseline"),
+        ("False", "off"),
+        ("true", "baseline"),
+        ("false", "off"),
+        ("'yes'", "baseline"),
+        ('"no"', "off"),
+        ("'baseline'", None),
+        ("'off'", None),
+        ("'on'", None),
+        ("some_var()", None),
+    ],
+)
+def test_normalize_static_analysis_source(source, expected):
+    assert normalize_static_analysis_source(source) == expected
+
+
+def _run_yml(yml_str: str) -> str:
+    content = YMLContent(original_str=yml_str, original_parsed=None, current_str=yml_str)
+    result = changeset_normalize_static_analysis_yml(content, None)
+    return result.refactored_yaml if result.refactored else yml_str
+
+
+def test_dbt_project_yml_conversion():
+    yml_str = "\n".join(
+        [
+            "static_analysis: True",
+            "models:",
+            "  my_project:",
+            "    +static_analysis: False",
+            "    staging:",
+            "      +static_analysis: yes",
+            "    valid_zone:",
+            "      +static_analysis: baseline",
+            "    off_zone:",
+            "      +static_analysis: off",
+        ]
+    )
+    out = _run_yml(yml_str)
+    assert "static_analysis: 'baseline'" in out
+    assert "+static_analysis: 'off'" in out
+    # Already-valid enum values are preserved as-is (unquoted).
+    assert "+static_analysis: baseline" in out
+    assert "+static_analysis: off" in out
+
+
+def test_schema_yml_conversion():
+    yml_str = "\n".join(
+        [
+            "models:",
+            "  - name: my_model",
+            "    config:",
+            "      static_analysis: True",
+            "  - name: valid_model",
+            "    config:",
+            "      static_analysis: strict",
+        ]
+    )
+    out = _run_yml(yml_str)
+    assert "static_analysis: 'baseline'" in out
+    assert "static_analysis: strict" in out
+
+
+def test_schema_yml_no_change_is_noop():
+    yml_str = "\n".join(
+        [
+            "models:",
+            "  - name: valid_model",
+            "    config:",
+            "      static_analysis: baseline",
+        ]
+    )
+    content = YMLContent(original_str=yml_str, original_parsed=None, current_str=yml_str)
+    result = changeset_normalize_static_analysis_yml(content, None)
+    assert result.refactored is False
+
+
+def _run_sql(sql: str) -> str:
+    content = SQLContent(original_str=sql, current_str=sql, current_file_path=Path("x.sql"))
+    result = refactor_static_analysis_sql(content, None)
+    return result.refactored_content
+
+
+def test_sql_config_conversion_true():
+    sql = "{{ config(\n    materialized='table',\n    static_analysis=True\n) }}\n\nselect 1 as id\n"
+    out = _run_sql(sql)
+    assert "static_analysis='baseline'" in out
+    assert "materialized='table'" in out
+
+
+def test_sql_config_conversion_false():
+    sql = "{{ config(static_analysis=False) }}\nselect 1"
+    out = _run_sql(sql)
+    assert "static_analysis='off'" in out
+
+
+def test_sql_config_ignores_config_in_comment():
+    # A ``{{ config() }}`` in a comment must not shadow the real config block.
+    sql = (
+        "-- example {{ config() }} in a comment\n"
+        "-- static_analysis=True should be rewritten\n"
+        "{{ config(\n    materialized='view',\n    static_analysis=True\n) }}\n\nselect 1\n"
+    )
+    out = _run_sql(sql)
+    assert "static_analysis='baseline'" in out
+
+
+def test_sql_config_already_valid_is_noop():
+    sql = "{{ config(static_analysis='strict') }}\nselect 1"
+    content = SQLContent(original_str=sql, current_str=sql, current_file_path=Path("x.sql"))
+    result = refactor_static_analysis_sql(content, None)
+    assert result.refactored is False

--- a/tests/unit_tests/test_static_analysis.py
+++ b/tests/unit_tests/test_static_analysis.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from ruamel.yaml.comments import CommentedMap
 
 from dbt_autofix.refactors.changesets.dbt_sql import refactor_static_analysis_sql
 from dbt_autofix.refactors.results import SQLContent, YMLContent
@@ -57,7 +58,7 @@ def test_normalize_static_analysis_source(source, expected):
 
 
 def _run_yml(yml_str: str) -> str:
-    content = YMLContent(original_str=yml_str, original_parsed=None, current_str=yml_str)
+    content = YMLContent(original_str=yml_str, original_parsed=CommentedMap(), current_str=yml_str)
     result = changeset_normalize_static_analysis_yml(content, None)
     return result.refactored_yaml if result.refactored else yml_str
 
@@ -111,7 +112,7 @@ def test_schema_yml_no_change_is_noop():
             "      static_analysis: baseline",
         ]
     )
-    content = YMLContent(original_str=yml_str, original_parsed=None, current_str=yml_str)
+    content = YMLContent(original_str=yml_str, original_parsed=CommentedMap(), current_str=yml_str)
     result = changeset_normalize_static_analysis_yml(content, None)
     assert result.refactored is False
 


### PR DESCRIPTION
## Description

Fixes [dbt-labs/dbt-autofix#394](https://github.com/dbt-labs/dbt-autofix/issues/394).

Older projects set `static_analysis` to a boolean (`True`/`False`) or a truthy/falsy
spelling (`yes`/`no`), but the dbt platform / Fusion engine expects one of the string
enum values `unsafe | off | strict | baseline | on`. When Fusion loads such a project it
fails at manifest load with `dbt1150`:

> unknown variant `False`, expected one of `unsafe`, `off`, `strict`, `baseline`, `on`

`dbt-autofix` previously left these values unchanged (aside from incidental YAML casing
normalization on re-serialization), so the deprecation went unresolved. This PR adds a
new refactor rule that normalizes boolean `static_analysis` values to their enum
equivalents across every surface the config can appear on:

- `True` / `true` / `yes` → `'baseline'`
- `False` / `false` / `no` → `'off'`

Already-valid enum values (`on`, `off`, `baseline`, `strict`, `unsafe`) and any
unrecognized values are left untouched, so the rule is idempotent.

### Surfaces covered

1. **`dbt_project.yml`** — top-level `static_analysis` and `+static_analysis` under
   `models` / `seeds` / `snapshots` (including nested logical groupings).
2. **Schema YAML** — `config:` blocks at the model / seed / snapshot / source level.
3. **In-SQL `{{ config(...) }}`** — e.g. `static_analysis=True` → `static_analysis='baseline'`.

### Implementation notes

- New module `src/dbt_autofix/refactors/static_analysis.py` holds the shared
  normalization helpers and a recursive YAML changeset reused by both the
  `dbt_project.yml` and schema-YAML pipelines.
- Converted YAML values are emitted as single-quoted scalars (`'baseline'` / `'off'`) so
  they always serialize as strings.
- A relevant quirk: ruamel's round-trip loader parses YAML 1.2, so `on`/`off`/`yes`/`no`
  come back as **strings** while only `true`/`false`/`True`/`False` are booleans. The
  normalization handles both cases and deliberately preserves the valid enum members
  `on`/`off`.
- The SQL rule iterates over **all** `{{ config(...) }}` macros in a file rather than only
  the first. This makes it robust to a `{{ config() }}` appearing inside a comment ahead
  of the real config block (which would otherwise shadow it).
- Classified as a **safe change** (non-behavior-changing): it runs by default with
  `dbt-autofix deprecations` and under `--all`.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [x] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] If this is a bug fix:
    *   [x] Updated integration tests with bug repro (`project_static_analysis`)
    *   [x] Linked to bug report ticket (#394)
*   [x] Added unit tests if needed (`tests/unit_tests/test_static_analysis.py`)
*   [x] Updated unit tests if needed
*   [x] Tests passed when run locally (625 passed, 1 xpassed)
