### PR TITLE
Output availability of v2-compatible package versions during upgrades

### DIFF
--- a/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/dbt_package.py
+++ b/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/dbt_package.py
@@ -58,6 +58,7 @@ class DbtPackage:
     fusion_compatible_versions: list[VersionSpecifier] = field(default_factory=list)
     fusion_incompatible_versions: list[VersionSpecifier] = field(default_factory=list)
     unknown_compatibility_versions: list[VersionSpecifier] = field(default_factory=list)
+    v2_compatible_download_versions: list[VersionSpecifier] = field(default_factory=list)
 
     # check compatibility of latest and installed versions when loading
     latest_version_fusion_compatibility: PackageVersionFusionCompatibilityState = (
@@ -78,10 +79,12 @@ class DbtPackage:
         fusion_compatible_versions = convert_version_string_list_to_spec(output["fusion_compatible_versions"])
         fusion_incompatible_versions = convert_version_string_list_to_spec(output["fusion_incompatible_versions"])
         unknown_compatibility_versions = convert_version_string_list_to_spec(output["unknown_compatibility_versions"])
+        v2_compatible_download_versions = convert_version_string_list_to_spec(output["v2_compatible_download_versions"])
         self.lowest_fusion_compatible_version = oldest_fusion_compatible_version
         self.fusion_compatible_versions = fusion_compatible_versions
         self.fusion_incompatible_versions = fusion_incompatible_versions
         self.unknown_compatibility_versions = unknown_compatibility_versions
+        self.v2_compatible_download_versions = v2_compatible_download_versions
         return True
 
     def __post_init__(self):
@@ -141,6 +144,12 @@ class DbtPackage:
             else:
                 return self.package_versions[installed_version_string].get_fusion_compatibility_state()
 
+    def has_v2_compatible_download_for_installed_version(self) -> bool:
+        if self.installed_package_version is None:
+            return False
+        else:
+            return self.installed_package_version in self.v2_compatible_download_versions
+    
     def find_fusion_compatible_versions_in_requested_range(self) -> list[VersionSpecifier]:
         """Find package versions that are compatible with Fusion AND the version range specified in the project config.
 

--- a/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/dbt_package.py
+++ b/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/dbt_package.py
@@ -149,7 +149,7 @@ class DbtPackage:
             return False
         else:
             return self.installed_package_version in self.v2_compatible_download_versions
-    
+
     def find_fusion_compatible_versions_in_requested_range(self) -> list[VersionSpecifier]:
         """Find package versions that are compatible with Fusion AND the version range specified in the project config.
 

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -44,6 +44,7 @@ class PackageVersionUpgradeResult:
     version_range_config: Optional[str] = None
     upgraded: bool = False
     package_lock_version_found: bool = False
+    v2_compatible_download_available: bool = False
 
     def package_should_upgrade(self):
         return self.version_reason == PackageVersionUpgradeType.UPGRADE_AVAILABLE
@@ -76,6 +77,8 @@ class PackageVersionUpgradeResult:
             logs.append(
                 f"Compatible version is available ({self.compatible_version}): {self.upgraded_version_compatibility_state.value}"
             )
+        if self.v2_compatible_download_available:
+            logs.append("v2-compatible download available for installed version")
         return logs
 
     def to_dict(self) -> dict:
@@ -214,6 +217,11 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
     missing_compatibility = package_fusion_compatibility.get(
         PackageFusionCompatibilityState.MISSING_COMPATIBILITY, set()
     )
+    # if a package has v2-compatible downloads, consider that as having compatible versions
+    for package in deps_file.get_v2_compatible_downloads():
+        if package in no_versions_compatible:
+            no_versions_compatible.remove(package)
+            some_versions_compatible.add(package)
 
     # now, the actual work begins
 
@@ -226,6 +234,9 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
         installed_version_compat: PackageVersionFusionCompatibilityState = deps_file.package_dependencies[
             package
         ].is_installed_version_fusion_compatible()
+        installed_version_v2_download_available: bool = deps_file.package_dependencies[
+            package
+        ].has_v2_compatible_download_for_installed_version()
 
         # if version is compatible based on version range, include private packages
         if installed_version_compat == PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_INCLUDES_2_0:
@@ -240,6 +251,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=installed_version_compat,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -255,6 +267,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.UNKNOWN,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -274,6 +287,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=installed_version_compat,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -290,6 +304,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.EXPLICIT_ALLOW,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -305,6 +320,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_EXCLUDES_2_0,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -320,6 +336,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.UNKNOWN,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -330,13 +347,16 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
 
     # otherwise, check individual versions
     for package in deps_file.package_dependencies:
-        if package not in packages_to_check or package not in some_versions_compatible:
+        if package not in packages_to_check:
             continue
         dbt_package = deps_file.package_dependencies[package]
         installed_version: str = deps_file.package_dependencies[package].get_installed_package_version()
         installed_version_compat: PackageVersionFusionCompatibilityState = deps_file.package_dependencies[
             package
         ].is_installed_version_fusion_compatible()
+        installed_version_v2_download_available: bool = deps_file.package_dependencies[
+            package
+        ].has_v2_compatible_download_for_installed_version()
         package_version_range: Optional[VersionRange] = deps_file.package_dependencies[
             package
         ].project_config_version_range
@@ -371,6 +391,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     if package in EXPLICIT_ALLOW_ALL_VERSIONS
                     else PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_INCLUDES_2_0,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -389,6 +410,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     if package in EXPLICIT_ALLOW_ALL_VERSIONS
                     else PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_INCLUDES_2_0,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -405,6 +427,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=installed_version_compat,
                     upgraded_version_compatibility_state=PackageVersionFusionCompatibilityState.DBT_VERSION_RANGE_EXCLUDES_2_0,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
             packages_to_check.remove(package)
@@ -422,6 +445,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     installed_version_compatibility_state=PackageVersionFusionCompatibilityState.UNKNOWN,
                     upgraded_version_compatibility_state=None,
                     package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
                 )
             )
 
@@ -449,6 +473,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                             upgraded_version_compatibility_state=None,
                             upgraded=False,
                             package_lock_version_found=True,
+                            v2_compatible_download_available=installed_version_v2_download_available,
                         )
                     )
 

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -429,24 +429,28 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
     # but still display their compatibility information for reference
     if deps_file.has_lock_file and len(deps_file.transitive_dependencies) > 0:
         packages_already_checked: set[str] = set([x.id for x in package_version_upgrade_results])
-        for version in deps_file.transitive_dependencies:
-            if version not in packages_already_checked:
-                transitive_dependency_version: DbtPackageVersion = deps_file.transitive_dependencies[version]
-                transitive_dependency_compatibility: PackageVersionFusionCompatibilityState = (
-                    transitive_dependency_version.get_fusion_compatibility_state()
+        for package_id, package in deps_file.transitive_dependencies.items():
+            if package_id not in packages_already_checked:
+                transitive_dependency_version_str: str = package.get_installed_package_version()
+                transitive_dependency_version: Optional[DbtPackageVersion] = package.package_versions.get(
+                    transitive_dependency_version_str
                 )
-                package_version_upgrade_results.append(
-                    PackageVersionUpgradeResult(
-                        id=version,
-                        public_package=True,
-                        installed_version=transitive_dependency_version.package_version_str,
-                        version_reason=PackageVersionUpgradeType.TRANSITIVE_DEPENDENCY,
-                        installed_version_compatibility_state=transitive_dependency_compatibility,
-                        upgraded_version_compatibility_state=None,
-                        upgraded=False,
-                        package_lock_version_found=True,
+                if transitive_dependency_version is not None:
+                    transitive_dependency_compatibility: PackageVersionFusionCompatibilityState = (
+                        transitive_dependency_version.get_fusion_compatibility_state()
                     )
-                )
+                    package_version_upgrade_results.append(
+                        PackageVersionUpgradeResult(
+                            id=package_id,
+                            public_package=True,
+                            installed_version=transitive_dependency_version_str,
+                            version_reason=PackageVersionUpgradeType.TRANSITIVE_DEPENDENCY,
+                            installed_version_compatibility_state=transitive_dependency_compatibility,
+                            upgraded_version_compatibility_state=None,
+                            upgraded=False,
+                            package_lock_version_found=True,
+                        )
+                    )
 
     return package_version_upgrade_results
 

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -463,6 +463,7 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
                     transitive_dependency_compatibility: PackageVersionFusionCompatibilityState = (
                         transitive_dependency_version.get_fusion_compatibility_state()
                     )
+                    installed_version_v2_download_available = package.has_v2_compatible_download_for_installed_version()
                     package_version_upgrade_results.append(
                         PackageVersionUpgradeResult(
                             id=package_id,

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -252,6 +252,15 @@ class DbtPackageFile:
             compatibility[fusion_compatibility].add(package)
         return compatibility
 
+    def get_v2_compatible_downloads(self) -> set[str]:
+        """Return packages that have a v2-compatible download available."""
+        packages_with_v2_compatible_downloads: set[str] = set()
+        for package_id, package in self.package_dependencies.items():
+            if len(package.v2_compatible_download_versions) > 0:
+                packages_with_v2_compatible_downloads.add(package_id)
+
+        return packages_with_v2_compatible_downloads
+
 
 def parse_package_dependencies_from_yml(
     parsed_yml: dict[Any, Any], package_file_name: str, package_file_path: Optional[Path]

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -116,7 +116,7 @@ class DbtPackageFile:
     yml_dependencies: dict[Any, Any]
     # this is indexed by package id for uniqueness (hopefully)
     package_dependencies: dict[str, DbtPackage] = field(default_factory=dict)
-    transitive_dependencies: dict[str, DbtPackageVersion] = field(default_factory=dict)
+    transitive_dependencies: dict[str, DbtPackage] = field(default_factory=dict)
     unknown_packages: set[str] = field(default_factory=set)
     # track if the project has a package-lock.yml so we can determine canonical versions
     has_lock_file: bool = False
@@ -161,17 +161,20 @@ class DbtPackageFile:
     def merge_package_lock_versions(self, lock_file: DbtPackageLockFile) -> int:
         self.has_lock_file = True
         package_lock_found_in_deps: int = 0
-        for lock_file_package in lock_file.installed_package_versions:
-            lock_package_id: Optional[str] = lock_file.installed_package_versions[lock_file_package].package_id
+        for lock_file_package, lock_file_version in lock_file.installed_package_versions.items():
+            lock_package_id: Optional[str] = lock_file_version.package_id
             if lock_package_id is None or lock_package_id != lock_file_package:
                 lock_package_id = lock_package_id if lock_package_id is not None else lock_file_package
             if lock_file_package in self.package_dependencies:
-                self.set_installed_version_for_package(
-                    lock_package_id, lock_file.installed_package_versions[lock_package_id]
-                )
+                self.set_installed_version_for_package(lock_package_id, lock_file_version)
                 package_lock_found_in_deps += 1
             else:
-                self.transitive_dependencies[lock_package_id] = lock_file.installed_package_versions[lock_file_package]
+                self.transitive_dependencies[lock_package_id] = DbtPackage(
+                    package_id=lock_package_id,
+                    package_name=lock_file_version.package_name,
+                    project_config_raw_version_specifier=None,
+                )
+                self.transitive_dependencies[lock_package_id].add_package_version(lock_file_version, installed=True)
         assert package_lock_found_in_deps + len(self.transitive_dependencies) == len(
             lock_file.installed_package_versions
         )


### PR DESCRIPTION
## Description

When running package upgrades, output if the installed version has a v2-compatible version available that would allow the user to substitute that version instead of upgrading

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
