### PR TITLE
Wire up v2-compatible downloads option for package upgrades

### DIFF
--- a/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/upgrade_status.py
+++ b/packages/dbt_fusion_package_tools/src/dbt_fusion_package_tools/upgrade_status.py
@@ -9,6 +9,7 @@ class PackageVersionFusionCompatibilityState(str, Enum):
     DBT_VERSION_RANGE_INCLUDES_2_0 = "require-dbt-version includes version 2.0"
     EXPLICIT_ALLOW = "Version has been verified by dbt as Fusion-compatible even though its declared require-dbt-version may not include 2.0"
     EXPLICIT_DISALLOW = "Version has been verified by dbt as incompatible with Fusion"
+    V2_COMPATIBLE_DOWNLOAD = "Version is incompatible but has a v2-compatible package download available"
     UNKNOWN = "Version state unknown"
 
 
@@ -36,4 +37,5 @@ class PackageVersionUpgradeType(str, Enum):
     )
     PRIVATE_PACKAGE_MISSING_REQUIRE_DBT_VERSION = "Private package requires a compatible require-dbt-version (>=2.0.0, <3.0.0) to be available on Fusion. https://docs.getdbt.com/reference/project-configs/require-dbt-version"
     TRANSITIVE_DEPENDENCY = "Package is a transitive dependency of another package in your project"
+    PUBLIC_PACKAGE_HAS_V2_COMPATIBLE_DOWNLOAD = "Installed package version has a v2-compatible download available. Run dbt deps --use-v2-compatible-package-downloads flag"
     UNKNOWN = "Package's Fusion eligibility unknown"

--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -61,8 +61,9 @@ def upgrade_packages(
     v2_compatible_downloads: Annotated[
         bool,
         typer.Option(
+            "--use-v2-compatible-package-downloads",
+            "-v",
             "--v2-compatible-downloads",
-            "-f",
             help="Use v2-compatible downloads when available instead of upgrading",
             hidden=True,
         ),

--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -47,7 +47,9 @@ def identify_duplicate_keys(
 
 @app.command(name="packages")
 def upgrade_packages(
-    path: Annotated[Path, typer.Option("--path", "-p", help="The path to the dbt project")] = current_dir,
+    path: Annotated[
+        Path, typer.Option("--path", "-p", "--project-dir", help="The path to the dbt project")
+    ] = current_dir,
     dry_run: Annotated[bool, typer.Option("--dry-run", "-d", help="In dry run mode, do not apply changes")] = False,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output in JSON format")] = False,
     force_upgrade: Annotated[
@@ -102,7 +104,9 @@ def upgrade_packages(
 
 @app.command(name="deprecations")
 def refactor_yml(
-    path: Annotated[Path, typer.Option("--path", "-p", help="The path to the dbt project")] = current_dir,
+    path: Annotated[
+        Path, typer.Option("--path", "-p", "--project-dir", help="The path to the dbt project")
+    ] = current_dir,
     dry_run: Annotated[bool, typer.Option("--dry-run", "-d", help="In dry run mode, do not apply changes")] = False,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output in JSON format")] = False,
     exclude_dbt_project_keys: Annotated[

--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -56,6 +56,15 @@ def upgrade_packages(
             "--force-upgrade", "-f", help="Override package version config when upgrading to Fusion-compatible versions"
         ),
     ] = False,
+    v2_compatible_downloads: Annotated[
+        bool,
+        typer.Option(
+            "--v2-compatible-downloads",
+            "-f",
+            help="Use v2-compatible downloads when available instead of upgrading",
+            hidden=True,
+        ),
+    ] = False,
 ):
     if not path.is_dir() or not path.exists():
         error_console.print("[red]-- The directory specified in --path does not exist --[/red]")
@@ -72,7 +81,9 @@ def upgrade_packages(
             error_console.print("[red]-- No package dependencies found --[/red]")
             raise Exception()
 
-        package_upgrades: list[PackageVersionUpgradeResult] = check_for_package_upgrades(deps_file)
+        package_upgrades: list[PackageVersionUpgradeResult] = check_for_package_upgrades(
+            deps_file, prefer_v2_compatible_downloads=v2_compatible_downloads
+        )
 
         packages_upgraded: PackageUpgradeResult = upgrade_package_versions(
             deps_file=deps_file,
@@ -80,6 +91,7 @@ def upgrade_packages(
             dry_run=dry_run,
             override_pinned_version=force_upgrade,
             json_output=json_output,
+            prefer_v2_compatible_downloads=v2_compatible_downloads,
         )
         packages_upgraded.print_to_console(json_output=json_output)
     except:

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -189,6 +189,22 @@ def generate_package_dependencies(root_dir: Path) -> Optional[DbtPackageFile]:
 def check_for_package_upgrades(
     deps_file: DbtPackageFile, prefer_v2_compatible_downloads: bool = False
 ) -> list[PackageVersionUpgradeResult]:
+    """Determine if package versions are compatible and identify if upgrades are available.
+
+    This iterates through all the installed packages in the project and checks if the
+    installed package version is compatible with dbt v2. It also checks if the versions
+    have a v2-compatible package download available as an alternative to upgrading the
+    package version. If a version is not compatible, it will try to find a compatible
+    version within the project's defined version range, or else look for the first compatible
+    version about the project's defined version range.
+
+    Args:
+        deps_file (DbtPackageFile): the parsed packages.yml or dependencies.yml
+        prefer_v2_compatible_downloads (bool, optional): CLI option to prioritize v2-compatible downloads over upgrading a package's version. Defaults to False.
+
+    Returns:
+        list[PackageVersionUpgradeResult]: list of package versions with compatibility info
+    """
     # check all packages for upgrades
     # if dry run, write out package upgrades and exit
     package_version_upgrade_results: list[PackageVersionUpgradeResult] = []
@@ -525,7 +541,7 @@ def upgrade_package_versions(
         prefer_v2_compatible_downloads (bool, optional): If a package with an available upgrade also has a v2-compatible download for the currently installed version, use that instead of upgrading the package. Defaults to False.
 
     Returns:
-        PackageUpgradeResult: _description_
+        PackageUpgradeResult: final result of package upgrades output from CLI
     """
     # if package dependencies have upgrades:
     # update dependencies.yml

--- a/src/dbt_autofix/package_upgrade.py
+++ b/src/dbt_autofix/package_upgrade.py
@@ -186,7 +186,9 @@ def generate_package_dependencies(root_dir: Path) -> Optional[DbtPackageFile]:
     return deps_file
 
 
-def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersionUpgradeResult]:
+def check_for_package_upgrades(
+    deps_file: DbtPackageFile, prefer_v2_compatible_downloads: bool = False
+) -> list[PackageVersionUpgradeResult]:
     # check all packages for upgrades
     # if dry run, write out package upgrades and exit
     package_version_upgrade_results: list[PackageVersionUpgradeResult] = []
@@ -360,8 +362,31 @@ def check_for_package_upgrades(deps_file: DbtPackageFile) -> list[PackageVersion
         package_version_range: Optional[VersionRange] = deps_file.package_dependencies[
             package
         ].project_config_version_range
-
         installed_version_spec = dbt_package.installed_package_version
+
+        # If we know the installed version has a v2-compatible download,
+        # use that instead of upgrading
+        if (
+            prefer_v2_compatible_downloads
+            and installed_version_spec is not None
+            and installed_version_v2_download_available
+        ):
+            package_version_upgrade_results.append(
+                PackageVersionUpgradeResult(
+                    id=package,
+                    public_package=True,
+                    installed_version=installed_package_versions[package],
+                    compatible_version=installed_package_versions[package],
+                    version_reason=PackageVersionUpgradeType.PUBLIC_PACKAGE_HAS_V2_COMPATIBLE_DOWNLOAD,
+                    installed_version_compatibility_state=installed_version_compat,
+                    upgraded_version_compatibility_state=PackageVersionFusionCompatibilityState.V2_COMPATIBLE_DOWNLOAD,
+                    package_lock_version_found=has_package_lock_file,
+                    v2_compatible_download_available=installed_version_v2_download_available,
+                )
+            )
+            packages_to_check.remove(package)
+            continue
+
         # in case the user hadn't run dbt deps, estimate version
         if installed_version_spec is None:
             if package_version_range is not None:
@@ -487,7 +512,21 @@ def upgrade_package_versions(
     dry_run: bool = True,
     override_pinned_version: bool = False,
     json_output: bool = False,
+    prefer_v2_compatible_downloads: bool = False,
 ) -> PackageUpgradeResult:
+    """Upgrade incompatible package versions.
+
+    Args:
+        deps_file (DbtPackageFile): the parsed packages.yml or dependencies.yml
+        package_dependencies_with_upgrades (list[PackageVersionUpgradeResult]): result of check_for_package_upgrades
+        dry_run (bool, optional): CLI option that prints output without making changes. Defaults to True.
+        override_pinned_version (bool, optional): CLI option that will upgrade packages beyond the version range specified in the original packages.yml. Defaults to False.
+        json_output (bool, optional): CLI option to print logs output in JSON format. Defaults to False.
+        prefer_v2_compatible_downloads (bool, optional): If a package with an available upgrade also has a v2-compatible download for the currently installed version, use that instead of upgrading the package. Defaults to False.
+
+    Returns:
+        PackageUpgradeResult: _description_
+    """
     # if package dependencies have upgrades:
     # update dependencies.yml
     # update packages.yml


### PR DESCRIPTION
## Description

This change adds the initial scaffolding for the v2-compatible downloads CLI option for package upgrades. The CLI option is hidden because it's still a WIP. Currently this option will avoid upgrading the package version if a v2-compatible version is identified, but it will still change the packages.yml. Next steps are to carry through that change and also update the dbt_project.yml as needed.

I'm also adding `--project-dir` as an alias for `--path` in the CLI options so that it matches the CLI option in dbt core/Fusion. This resolves a long-standing user issue where the user, despite having worked on autofix for nearly a year, still types `--project-dir` instead of `--path` 99% of the time (it's me, I'm the user).

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [x] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
