### PR TITLE
Fix IsADirectoryError crash and bare except clauses

### DIFF
--- a/src/dbt_autofix/duplicate_keys.py
+++ b/src/dbt_autofix/duplicate_keys.py
@@ -59,6 +59,8 @@ def find_duplicate_keys(
 
     # Check project YML files
     for file in yml_files_not_target_or_packages:
+        if not file.is_file():
+            continue
         file_with_duplicate = False
         file_content = file.read_text()
         for p in yamllint.linter.run(file_content, yaml_config):
@@ -79,6 +81,8 @@ def find_duplicate_keys(
 
     # Check package YML files
     for file in yml_files_packages_not_integration_tests:
+        if not file.is_file():
+            continue
         file_content = file.read_text()
         for p in yamllint.linter.run(file_content, yaml_config):
             if p.rule == "key-duplicates":

--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -97,7 +97,7 @@ def upgrade_packages(
             prefer_v2_compatible_downloads=v2_compatible_downloads,
         )
         packages_upgraded.print_to_console(json_output=json_output)
-    except:
+    except Exception:
         error_console.print("[red]-- Package upgrade failed, please check logs for details --[/red]")
     if json_output:
         print(json.dumps({"mode": "complete"}))

--- a/src/dbt_autofix/packages/dbt_package_file.py
+++ b/src/dbt_autofix/packages/dbt_package_file.py
@@ -80,7 +80,7 @@ def load_yaml_from_packages_yml(packages_yml_path: Path) -> dict[Any, Any]:
 
     try:
         parsed_package_file = load_yaml(packages_yml_path)
-    except:
+    except Exception:
         console.log(f"Error when parsing package file {packages_yml_path}")
         return {}
     if parsed_package_file == {}:
@@ -99,7 +99,7 @@ def load_yaml_from_dependencies_yml(dependencies_yml_path: Path) -> dict[Any, An
 
     try:
         parsed_package_file = load_yaml(dependencies_yml_path)
-    except:
+    except Exception:
         console.log(f"Error when parsing package file {dependencies_yml_path}")
         return {}
     if parsed_package_file == {}:
@@ -128,7 +128,7 @@ class DbtPackageFile:
         try:
             self.yml_str = self.file_path.read_text()
             console.log(f"parsed yaml string: {self.yml_str}")
-        except:
+        except Exception:
             console.log(f"Error when parsing package file {self.file_path}")
 
     def add_package_dependency(self, package_id: str, package: DbtPackage):

--- a/src/dbt_autofix/packages/installed_packages.py
+++ b/src/dbt_autofix/packages/installed_packages.py
@@ -90,7 +90,7 @@ def load_yaml_from_package_dbt_project_yml_path(package_project_yml_path: Path) 
         return {}
     try:
         parsed_package_file = load_yaml(package_project_yml_path)
-    except:
+    except Exception:
         console.log(f"Error when parsing package file {package_project_yml_path}")
         return {}
     if parsed_package_file == {}:


### PR DESCRIPTION
## Summary

- **IsADirectoryError fix**: `glob('**/*.yml')` in `find_duplicate_keys()` can match directories, causing `IsADirectoryError` when `read_text()` is called. Added `is_file()` guards before reading in both project and package YML loops.
- **Bare except clauses**: Replaced 5 bare `except:` clauses with `except Exception:` across `main.py`, `dbt_package_file.py`, and `installed_packages.py` to avoid silently catching `SystemExit` and `KeyboardInterrupt`.

Fixes #384

## Test plan

- [ ] Run `dbt-autofix list-yaml-duplicates` on a project containing a directory ending in `.yml` — should skip it instead of crashing
- [ ] Run `dbt-autofix packages` and verify Ctrl+C still terminates immediately
- [ ] Existing tests pass with no regressions