### PR TITLE
Allow missing versions when parsing package dbt_project.yml

### DIFF
--- a/src/dbt_autofix/packages/installed_packages.py
+++ b/src/dbt_autofix/packages/installed_packages.py
@@ -118,11 +118,13 @@ def parse_package_info_from_package_dbt_project_yml(parsed_package_file: dict[An
         console.log("Package must contain name")
         return
 
+    # the version listed in the package's dbt_project.yml is arbitrary and
+    # typically doesn't reflect the actual package version (which Package Hub
+    # derives from the git tag in the package repo)
     if "version" in parsed_package_file:
         version = str(parsed_package_file["version"])
     else:
-        console.log("Package must contain version")
-        return
+        version = "0.0.0"
 
     if "require-dbt-version" in parsed_package_file:
         require_dbt_version_raw: Any = parsed_package_file["require-dbt-version"]


### PR DESCRIPTION
## Description

Continue parsing for packages that don't have a version defined in dbt_project.yml (instead of exiting immediately). Originally autofix used the version string from the package's dbt_project.yml to determine the installed version, but it turns out that this string is totally arbitrary and often doesn't even match the package version so autofix doesn't actually use it for any of the upgrade logic. So we should continue parsing the package even if it's missing this.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [ ] Tests passed when run locally
