### PR TITLE
Fix receiver stripping in CONFIG_ACCESS_PATTERN for `<ident>_model.config.get(...)`

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_sql_improved.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql_improved.py
@@ -15,8 +15,16 @@ CONFIG_ALIAS_PATTERN = re.compile(r"{%\s*set\s+\w+\s*=\s*config\s*%}")
 # - Optional whitespace (including multiline)
 # - Optional default parameter
 # - Optional validator parameter
+#
+# The optional `model.` prefix is consumed (and dropped) so `model.config.get(...)`
+# becomes `config.meta_get(...)`. The lookbehind keeps that prefix from matching
+# mid-identifier: without it, `test_model.config.get(...)` matches starting at
+# `model.`, and stripping the match leaves the orphaned `test_` fused onto the
+# replacement -> `test_config.meta_get(...)`, an undefined Jinja variable.
+# Any other receiver (`node.`, `test_model.`, ...) falls outside the match and is
+# preserved, e.g. `node.config.get(...)` -> `node.config.meta_get(...)`.
 CONFIG_ACCESS_PATTERN = re.compile(
-    r"(model.)?config\.(get|require)\s*\("  # config.get( or config.require(
+    r"(?:(?<![\w.])model\.)?config\.(?P<method>get|require)\s*\("  # config.get( or config.require(
     r"(?P<pre_ws>\s*)"  # whitespace before the key
     r"(?P<quote>[\"'])(?P<key>[^\"']+)(?P=quote)"  # quoted key with captured quote style
     r"(?P<rest>.*?)"  # rest of the call including args and whitespace
@@ -74,7 +82,7 @@ def move_custom_config_access_to_meta_sql_improved(
     replacements: List[Tuple[int, int, str, str]] = []
 
     for match in matches:
-        method = match.group(2)  # 'get' or 'require'
+        method = match.group("method")  # 'get' or 'require'
         pre_whitespace = match.group("pre_ws")  # Whitespace before key
         quote_style = match.group("quote")  # Preserve original quote style
         config_key = match.group("key")

--- a/tests/unit_tests/test_config_meta_autofix.py
+++ b/tests/unit_tests/test_config_meta_autofix.py
@@ -291,3 +291,90 @@ SELECT
     assert result.refactored
     assert result.refactored_content == expected_sql
     assert len(result.deprecation_refactors) == 1
+
+
+def test_prefixed_model_receiver_is_not_mangled():
+    """A receiver ending in `model` must not have its prefix orphaned.
+
+    Regression test: the optional `model.` prefix used to match mid-identifier, so
+    `test_model.config.get(...)` matched starting at `model.`. Dropping that match
+    left the orphaned `test_` fused onto the replacement, producing
+    `test_config.meta_get(...)` -- an undefined Jinja variable that fails at render
+    time. See dbt-labs/fs#12687.
+    """
+    input_sql = """
+SELECT
+    '{{ test_model.config.get('custom_key') }}' as custom
+"""
+
+    expected_sql = """
+SELECT
+    '{{ test_model.config.meta_get('custom_key') }}' as custom
+"""
+
+    result = move_custom_config_access_to_meta_sql_improved(_sql(input_sql), _sql_cfg())
+
+    assert result.refactored
+    assert result.refactored_content == expected_sql
+    assert "test_config" not in result.refactored_content
+    assert len(result.deprecation_refactors) == 1
+
+
+def test_non_model_receiver_is_preserved():
+    """An arbitrary receiver sits outside the match and must survive untouched."""
+    input_sql = """
+SELECT
+    '{{ node.config.get('custom_key', 'false') }}' as custom
+"""
+
+    expected_sql = """
+SELECT
+    '{{ node.config.meta_get('custom_key', 'false') }}' as custom
+"""
+
+    result = move_custom_config_access_to_meta_sql_improved(_sql(input_sql), _sql_cfg())
+
+    assert result.refactored
+    assert result.refactored_content == expected_sql
+    assert len(result.deprecation_refactors) == 1
+
+
+def test_prefixed_model_receiver_with_require():
+    """The same boundary rule applies to `config.require(...)`."""
+    input_sql = "SELECT '{{ this_model.config.require('custom_key') }}' as custom"
+    expected_sql = "SELECT '{{ this_model.config.meta_require('custom_key') }}' as custom"
+
+    result = move_custom_config_access_to_meta_sql_improved(_sql(input_sql), _sql_cfg())
+
+    assert result.refactored
+    assert result.refactored_content == expected_sql
+    assert "this_config" not in result.refactored_content
+
+
+def test_dbt_constraints_style_receivers():
+    """Real-world shape from the dbt_constraints package that triggered dbt-labs/fs#12687.
+
+    Exercises all three receiver forms in one template: a `test_model.` prefix, a bare
+    `node.` receiver, and a plain `model.` prefix that is still stripped as before.
+    """
+    input_sql = """
+{%- if test_model.config.get("dbt_constraints_enabled", "true")|string|lower == "true"
+    or node.config.get("always_create_constraint", "false")|string|lower == "true"
+    or model.config.get("custom_key", "false")|string|lower == "true" -%}
+    {{ return(true) }}
+{%- endif -%}
+"""
+
+    expected_sql = """
+{%- if test_model.config.meta_get("dbt_constraints_enabled", "true")|string|lower == "true"
+    or node.config.meta_get("always_create_constraint", "false")|string|lower == "true"
+    or config.meta_get("custom_key", "false")|string|lower == "true" -%}
+    {{ return(true) }}
+{%- endif -%}
+"""
+
+    result = move_custom_config_access_to_meta_sql_improved(_sql(input_sql), _sql_cfg())
+
+    assert result.refactored
+    assert result.refactored_content == expected_sql
+    assert len(result.deprecation_refactors) == 3


### PR DESCRIPTION
## Description

`CONFIG_ACCESS_PATTERN`'s optional `model.` prefix had no left boundary, so it matched mid-identifier. In `test_model.config.get("k")` the match began at `model.`, and because the replacement discards that prefix, the orphaned `test_` fused onto it:

```
test_model.config.get("dbt_constraints_enabled", "true")
  ->  test_config.meta_get("dbt_constraints_enabled", "true")
```

`test_config` is not a bound Jinja name, so the rendered template fails with `unknown method: undefined has no method named meta_get`.

This stayed latent until build conformance began running deprecation rewrites on **installed packages** as well as the project. `dbt_constraints` uses `test_model.config.get(...)` in two places in `create_constraints.sql`, so its `on-run-end` hook started failing — ~213 projects across 66 accounts, of which ~60 are blocked solely by this. Root-cause detail and impact data: dbt-labs/fs#12687.

### Fix

Add a `(?<![\w.])` lookbehind to the prefix group so it only matches a standalone `model.`, and escape its `.` (it was an unescaped any-char).

Existing behaviour is deliberately preserved: a bare `model.` prefix is still stripped to `config.meta_get(...)`, as asserted by `test_model_config_get_refactor` and the `project1` integration golden. Any other receiver now falls outside the match and survives — which is how `node.config.get(...)` already behaved.

| input | before | after |
|---|---|---|
| `test_model.config.get("k","v")` | `test_config.meta_get(...)` ❌ | `test_model.config.meta_get(...)` ✅ |
| `this_model.config.require("k")` | `this_config.meta_require(...)` ❌ | `this_model.config.meta_require(...)` ✅ |
| `model.config.get("k")` | `config.meta_get("k")` | unchanged |
| `node.config.get("k")` | `node.config.meta_get("k")` | unchanged |
| `config.get("k")` | `config.meta_get("k")` | unchanged |

The method group is named rather than renumbered — making the prefix group non-capturing shifts the positional indices, and `match.group(2)` was the only index-based access left in the function.

Any project with `<ident>_model.config.get("custom_key")` in its macros is affected, not just dbt_constraints.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [x] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro — **intentionally skipped** (see note below)
    *   [x] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [ ] Updated unit tests if needed — no existing test needed changing
*   [x] Tests passed when run locally

### Tests

Four cases added to `tests/unit_tests/test_config_meta_autofix.py`:

* `test_prefixed_model_receiver_is_not_mangled` — the regression itself, asserting `test_config` does not appear in the output
* `test_non_model_receiver_is_preserved` — guards `node.config.get(...)`
* `test_prefixed_model_receiver_with_require` — same boundary rule for `config.require(...)`
* `test_dbt_constraints_style_receivers` — the real-world shape, exercising `test_model.`, `node.` and `model.` receivers in one template

`pytest tests/unit_tests/test_config_meta_autofix.py` → 16 passed.

### Note on the two unchecked boxes

**Integration repro skipped by request.** The natural home is `project1`, whose `test_project_refactor[project1]` is already failing on `main` — the harness compares `logs/dbt.log`, which any local `dbt` binary regenerates. `ignore_patterns` in `compare_dirs` lists `logs`, but the filter is only applied to `left_only`/`right_only`, so `common_dirs` recursion still reaches inside it. Probably worth fixing separately, along with a `GOLDIE_UPDATE=1` refresh.

**Full-suite status:** 632 passed, 1 failed — that one failure is `test_project_refactor[project1]`, confirmed pre-existing by re-running it against a stashed clean `main`. Since it is red either way, it cannot tell us whether this change alters that project's output, so I verified directly that the refactored `config.get`/`model.config.get` call sites in `project1` still match the expected golden exactly.
