### PR TITLE
fix: preserve snapshot configs in model paths

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -1,3 +1,4 @@
+import ast
 import re
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
@@ -291,6 +292,23 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
 
     allowed_config_fields = schema_specs.yaml_specs_per_node_type[node_type].allowed_config_fields
 
+    # A snapshot can live under model-paths and declare its materialization in SQL.
+    # Preserve snapshot-owned keys for dynamic materializations too; resolving the
+    # effective materialization would require rendering project configuration.
+    if node_type == "models" and "materialized" in original_sql_configs:
+        try:
+            materialized = ast.literal_eval(original_sql_configs["materialized"])
+        except (ValueError, SyntaxError):
+            materialized = None
+
+        if materialized is None or materialized == "snapshot" or (
+            isinstance(materialized, str) and ("{{" in materialized or "{%" in materialized)
+        ):
+            allowed_config_fields = allowed_config_fields.union(
+                schema_specs.yaml_specs_per_node_type["snapshots"].allowed_config_fields,
+                {"target_schema", "target_database"},
+            )
+
     # Special casing snapshots because target_schema and target_database are renamed by another autofix rule
     if node_type == "snapshots":
         allowed_config_fields = allowed_config_fields.union({"target_schema", "target_database"})
@@ -318,8 +336,6 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
                 existing_meta = refactored_sql_configs["meta"]
                 if isinstance(existing_meta, str):
                     # It's a source code string like "{'key': 'value'}" - parse it
-                    import ast
-
                     try:
                         parsed_meta = ast.literal_eval(existing_meta)
                         meta_dict = {k: meta_transform_value(v) for k, v in parsed_meta.items()}

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -301,8 +301,10 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
         except (ValueError, SyntaxError):
             materialized = None
 
-        if materialized is None or materialized == "snapshot" or (
-            isinstance(materialized, str) and ("{{" in materialized or "{%" in materialized)
+        if (
+            materialized is None
+            or materialized == "snapshot"
+            or (isinstance(materialized, str) and ("{{" in materialized or "{%" in materialized))
         ):
             allowed_config_fields = allowed_config_fields.union(
                 schema_specs.yaml_specs_per_node_type["snapshots"].allowed_config_fields,

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -2674,6 +2674,74 @@ def test_config_regex(input_str, expected_match):
 class TestRefactorCustomConfigsToMetaSQL:
     """Tests for refactor_custom_configs_to_meta_sql function"""
 
+    def test_snapshot_configs_in_model_path_stay_top_level(self, schema_specs: SchemaSpecs):
+        sql_content = """{{ config(
+    materialized='snapshot',
+    strategy='timestamp',
+    updated_at='updated_at',
+    check_cols=['id'],
+    custom_config='value',
+) }}
+
+select 1 as id
+"""
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert result.refactored
+        assert "materialized='snapshot'" in result.refactored_content
+        assert "strategy='timestamp'" in result.refactored_content
+        assert "updated_at='updated_at'" in result.refactored_content
+        assert "check_cols=['id']" in result.refactored_content
+        assert "meta={'custom_config': 'value'}" in result.refactored_content
+
+    def test_dynamic_materialization_preserves_snapshot_configs(self, schema_specs: SchemaSpecs):
+        sql_content = """{{ config(
+    materialized=var('materialization'),
+    strategy='timestamp',
+    custom_config='value',
+) }}
+
+select 1 as id
+"""
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert result.refactored
+        assert "materialized=var('materialization')" in result.refactored_content
+        assert "strategy='timestamp'" in result.refactored_content
+        assert "meta={'custom_config': 'value'}" in result.refactored_content
+
+    def test_non_snapshot_materialization_moves_snapshot_named_custom_configs(self, schema_specs: SchemaSpecs):
+        sql_content = """{{ config(
+    materialized='table',
+    strategy='not_a_snapshot_strategy',
+) }}
+
+select 1 as id
+"""
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert result.refactored
+        assert "strategy='not_a_snapshot_strategy'" not in result.refactored_content
+        assert "meta={'strategy': 'not_a_snapshot_strategy'}" in result.refactored_content
+
+    def test_quoted_dynamic_materialization_preserves_snapshot_configs(self, schema_specs: SchemaSpecs):
+        sql_content = """{{ config(
+    materialized="{{ var('materialization') }}",
+    strategy='timestamp',
+) }}
+
+select 1 as id
+"""
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert not result.refactored
+        assert result.refactored_content == sql_content
+        assert "strategy='timestamp'" in result.refactored_content
+
     def test_on_error_not_moved_to_meta(self, schema_specs: SchemaSpecs):
         """on_error is a recognized Fusion config key and should NOT be moved to meta"""
         sql_content = """{{


### PR DESCRIPTION
Fixes dbt-labs/fs#12903

## Summary

dbt-autofix classified SQL files by their directory. A snapshot in a model path was treated as a model. Autofix then moved snapshot settings from the top-level config to meta. Fusion could not find the snapshot strategy.

## Changes

- Keep snapshot settings in the top-level config for literal and dynamic materializations.
- Keep target_schema and target_database available for snapshot config renames.
- Keep the current custom-config behavior for normal models.
- Add tests for literal, dynamic, quoted Jinja, and normal model cases.

## Tests

- uv run pytest tests/unit_tests -q
- uv run ruff check src/dbt_autofix/refactors/changesets/dbt_sql.py tests/unit_tests/test_refactor.py
- git diff --check

The unit tests pass: 629 passed, 1 xpassed.