### PR TITLE
fix: preserve adapter-specific configs instead of moving them to +meta

### DIFF
--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 import yamllint.config
 
-from dbt_autofix.refactors.constants import DBT_PROJECT_CONFIG_MISSPELLINGS
+from dbt_autofix.refactors.constants import ADAPTER_SPECIFIC_CONFIGS, DBT_PROJECT_CONFIG_MISSPELLINGS
 from dbt_autofix.refactors.results import (
     DbtDeprecationRefactor,
     DbtProjectYMLRefactorConfig,
@@ -239,6 +239,11 @@ def rec_check_yaml_path(
                                     else:
                                         refactor_logs.append(log_msg)
                     # Otherwise keep as-is (value is the config value)
+
+                # Adapter-specific config: not in the (core-only) schema, but functional.
+                # Leave it alone - moving it to +meta would silently change behaviour.
+                elif key_without_plus in ADAPTER_SPECIFIC_CONFIGS:
+                    pass
 
                 # Unrecognized config (not in schema), move to +meta
                 else:

--- a/src/dbt_autofix/refactors/constants.py
+++ b/src/dbt_autofix/refactors/constants.py
@@ -15,3 +15,13 @@ COMMON_CONFIG_MISSPELLINGS = {"post-hook": "post_hook", "pre-hook": "pre_hook"}
 # unknown config and moved to +meta, which silently disables a functional hook. Map it back to the
 # hyphenated form instead.
 DBT_PROJECT_CONFIG_MISSPELLINGS = {"pre_hook": "pre-hook", "post_hook": "post-hook"}
+
+# Adapter-specific configs that are functional in dbt-core but absent from the Fusion JSON schema,
+# which only describes core configs. Without this allowlist they look like unknown configs and get
+# moved to +meta, where the adapter can no longer read them - silently changing behaviour.
+#
+# - `options`: dbt-duckdb's write options for the `external` materialization. Read via
+#   `config.get('options')` in its `render_write_options` macro, so moving it under +meta silently
+#   drops `partition_by`, `overwrite_or_ignore`, csv `delimiter`, etc. from the emitted COPY TO.
+#   https://github.com/duckdb/dbt-duckdb#writing-to-external-files
+ADAPTER_SPECIFIC_CONFIGS = {"options"}

--- a/tests/unit_tests/test_rec_check_yaml_path.py
+++ b/tests/unit_tests/test_rec_check_yaml_path.py
@@ -88,6 +88,29 @@ def test_correct_configs_unchanged(models_node_fields, temp_path):
     assert len(logs) == 0
 
 
+def test_adapter_specific_config_unchanged(models_node_fields, temp_path):
+    """INPUT:  +options (dbt-duckdb write options for the external materialization)
+    OUTPUT: Same, no changes
+    WHY:    The Fusion schema only describes core configs, so adapter-specific ones look
+            unrecognized. dbt-duckdb reads this via config.get('options'), so moving it to
+            +meta would silently drop partition_by/overwrite_or_ignore from the COPY TO.
+    """
+    input_dict = {
+        "+materialized": "external",
+        "+options": {"partition_by": "country", "overwrite_or_ignore": 1},
+    }
+
+    expected_output = {
+        "+materialized": "external",
+        "+options": {"partition_by": "country", "overwrite_or_ignore": 1},
+    }
+
+    result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
+
+    assert result == expected_output
+    assert len(logs) == 0
+
+
 # =============================================================================
 # SCENARIO 2: Schema does not support the key - moved to meta
 # =============================================================================


### PR DESCRIPTION
Fixes #412

### Problem

`+options` in `dbt_project.yml` is [dbt-duckdb]'s write-options config for the `external` materialization. `dbt-autofix` treats it as an unrecognized config and moves it under `+meta`.

That is a silent behaviour break. dbt-duckdb reads the config via `config.get('options')` in its `render_write_options` macro:

```jinja
{% macro render_write_options(config) -%}
  {% set options = config.get('options', {}) %}
```

Under `+meta` that lookup returns `{}`, so `partition_by`, `overwrite_or_ignore`, csv `delimiter` etc. are dropped from the emitted `COPY TO`. Nothing errors - partitioned writes just quietly become unpartitioned ones.

### Cause

The rule validates against the Fusion JSON schema, which only describes **core** configs, so adapter-specific configs are indistinguishable from user-defined custom configs.

### Fix

Adds an `ADAPTER_SPECIFIC_CONFIGS` allowlist and leaves those keys untouched. This mirrors the existing `DBT_PROJECT_CONFIG_MISSPELLINGS` carve-out added for the underscore hook forms in #373 - same class of bug, same shape of fix.

Seeded with dbt-duckdb's `options`; other adapters can be added as they come up.

### Tests

- New `test_adapter_specific_config_unchanged` asserting `+options` round-trips unchanged with no logs.
- Full unit suite passes (630 passed, 1 xpassed).
- Verified end-to-end on a minimal dbt-duckdb project: `+options` is now preserved.

[dbt-duckdb]: https://github.com/duckdb/dbt-duckdb