### PR TITLE
feat: add --skip-rule to disable individual rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ uv tool install --from git+https://github.com/dbt-labs/dbt-autofix.git dbt-autof
   - add `--include-private-packages` to autofix just the _private_ packages (those not on [hub.getdbt.com](https://hub.getdbt.com/)) installed. Just note that those fixes will be reverted at the next `dbt deps` and the long term fix will be to update the packages to versions compatible with Fusion.
   - add `--behavior-change` to run the _subset_ of fixes that would resolve deprecations that require a behavior change. Refer to the coverage tables above to determine which deprecations require behavior changes.
   - add `--all` to run all of the fixes possible - both fixes that potentially require behavior changes as well as not. Additionally, `--all` will apply fixes to as many files as possible, even if some files are unfixable (e.g. due to invalid yaml syntax).
+  - add `--skip-rule <rule>` to skip an individual rule, using the same name the rule is reported under in the output. Repeatable. Useful when one rule conflicts with your project (e.g. adapter-specific configs that are not in the Fusion schema) and you don't want to give up the other fixes:
+
+```sh
+dbt-autofix deprecations --skip-rule prefix_plus_for_config
+```
 
 Each JSON object will have the following keys:
 
@@ -177,4 +182,7 @@ repos:
       # OR
       - id: dbt-autofix-fix # Specify dbt project path
         args: [--path=jaffle-shop]
+      # OR
+      - id: dbt-autofix-fix # Skip an individual rule
+        args: [--skip-rule=prefix_plus_for_config]
 ```

--- a/pre_commit_hooks/check_deprecations.py
+++ b/pre_commit_hooks/check_deprecations.py
@@ -92,6 +92,14 @@ def parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Exclude dbt_project.yml keys from refactoring",
     )
     parser.add_argument(
+        "--skip-rule",
+        action="append",
+        default=None,
+        dest="skip_rule",
+        metavar="RULE",
+        help="Rule to skip, as named in the output (e.g. 'prefix_plus_for_config'). Repeatable.",
+    )
+    parser.add_argument(
         "--path",
         "-p",
         type=str,
@@ -136,6 +144,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         behavior_change=args.behavior_change,
         all=args.all,
         semantic_layer=args.semantic_layer,
+        skip_rules=set(args.skip_rule) if args.skip_rule else None,
     )
 
     if args.dry_run:

--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -141,6 +141,13 @@ def refactor_yml(
         bool, typer.Option("--all", help="Run all fixes, including those that may require a behavior change")
     ] = False,
     semantic_layer: Annotated[bool, typer.Option("--semantic-layer", help="Run fixes to semantic layer")] = False,
+    skip_rule: Annotated[
+        Optional[List[str]],
+        typer.Option(
+            "--skip-rule",
+            help="Rule to skip, as named in the output (e.g. 'prefix_plus_for_config'). Repeatable.",
+        ),
+    ] = None,
     disable_ssl_verification: Annotated[
         bool, typer.Option("--disable-ssl-verification", help="Disable SSL verification", hidden=True)
     ] = False,
@@ -161,6 +168,7 @@ def refactor_yml(
         behavior_change,
         all,
         semantic_layer,
+        set(skip_rule) if skip_rule else None,
     )
     if dry_run:
         if not json_output:

--- a/src/dbt_autofix/refactor.py
+++ b/src/dbt_autofix/refactor.py
@@ -90,6 +90,7 @@ def process_yaml_files_except_dbt_project(
     semantic_definitions: Optional[SemanticDefinitions] = None,
     project_has_unsafe_table_format: bool = False,
     dbtignore: Optional[pathspec.PathSpec] = None,
+    skip_rules: Optional[Set[str]] = None,
 ) -> List[YMLRefactorResult]:
     """Process all YAML files in the project.
 
@@ -104,12 +105,14 @@ def process_yaml_files_except_dbt_project(
         project_has_unsafe_table_format: Whether dbt_project.yml has a non-Iceberg table_format
             set alongside Iceberg-only model settings, computed once for the whole project
         dbtignore: Optional PathSpec from .dbtignore for filtering files
+        skip_rules: Optional set of rule names to skip
     """
     file_name_to_yaml_results: Dict[str, YMLRefactorResult] = {}
 
     config = YMLRefactorConfig(
         schema_specs=schema_specs,
         project_has_unsafe_table_format=project_has_unsafe_table_format,
+        skip_rules=skip_rules or set(),
     )
 
     behavior_change_rules: List[Callable] = [
@@ -138,6 +141,7 @@ def process_yaml_files_except_dbt_project(
             schema_specs=schema_specs,
             semantic_definitions=semantic_definitions,
             project_has_unsafe_table_format=config.project_has_unsafe_table_format,
+            skip_rules=skip_rules or set(),
         )
         # Certain changesets can only be applied after all the other changesets have been applied to all the files
         ordered_changesets = [
@@ -219,6 +223,7 @@ def process_dbt_project_yml(
     exclude_dbt_project_keys: bool = False,
     behavior_change: bool = False,
     all: bool = False,
+    skip_rules: Optional[Set[str]] = None,
 ) -> YMLRefactorResult:
     """Process dbt_project.yml."""
     if not (root_path / "dbt_project.yml").exists():
@@ -250,6 +255,7 @@ def process_dbt_project_yml(
         schema_specs=schema_specs,
         root_path=root_path,
         exclude_dbt_project_keys=exclude_dbt_project_keys,
+        skip_rules=skip_rules or set(),
     )
 
     behavior_change_rules: List[Callable] = [changeset_dbt_project_flip_behavior_flags]
@@ -325,6 +331,7 @@ def process_sql_files(
     all: bool = False,
     project_has_unsafe_table_format: bool = False,
     dbtignore: Optional[pathspec.PathSpec] = None,
+    skip_rules: Optional[Set[str]] = None,
 ) -> List[SQLRefactorResult]:
     """Process all SQL files in the given paths for unmatched endings.
 
@@ -338,6 +345,7 @@ def process_sql_files(
         project_has_unsafe_table_format: Whether dbt_project.yml has a non-Iceberg table_format
             set alongside Iceberg-only model settings, computed once for the whole project
         dbtignore: Optional PathSpec from .dbtignore for filtering files
+        skip_rules: Optional set of rule names to skip
 
     Returns:
         List of SQLRefactorResult for each processed file
@@ -368,6 +376,7 @@ def process_sql_files(
             schema_specs=schema_specs,
             node_type=node_type,
             project_has_unsafe_table_format=project_has_unsafe_table_format,
+            skip_rules=skip_rules or set(),
         )
 
         sql_files = full_path.glob("**/*.sql")
@@ -410,6 +419,7 @@ def process_python_files(
     behavior_change: bool = False,
     all: bool = False,
     dbtignore: Optional[pathspec.PathSpec] = None,
+    skip_rules: Optional[Set[str]] = None,
 ) -> List[PythonRefactorResult]:
     """Process all Python model files in the given paths.
 
@@ -425,6 +435,7 @@ def process_python_files(
         behavior_change: Whether to apply fixes that may lead to behavior change
         all: Whether to run all fixes
         dbtignore: Optional PathSpec from .dbtignore for filtering files
+        skip_rules: Optional set of rule names to skip
 
     Returns:
         List of PythonRefactorResult for each processed file
@@ -451,7 +462,7 @@ def process_python_files(
         if not full_path.exists():
             continue
 
-        config = PythonRefactorConfig(schema_specs=schema_specs, node_type=node_type)
+        config = PythonRefactorConfig(schema_specs=schema_specs, node_type=node_type, skip_rules=skip_rules or set())
 
         python_files = full_path.glob("**/*.py")
         for python_file in python_files:
@@ -616,6 +627,7 @@ def changeset_all_files(
     behavior_change: bool = False,
     all: bool = False,
     semantic_layer: bool = False,
+    skip_rules: Optional[Set[str]] = None,
 ) -> Tuple[List[YMLRefactorResult], List[SQLRefactorResult], List[PythonRefactorResult]]:
     """Process all YAML, SQL, and Python files in the project.
 
@@ -630,6 +642,7 @@ def changeset_all_files(
         behavior_change: Whether to apply fixes that may lead to behavior changes
         all: Whether to run all fixes, including those that may require a behavior change
         semantic_layer: Whether to run fixes to semantic layer
+        skip_rules: Optional set of rule names to skip
 
     Returns:
         Tuple containing:
@@ -646,7 +659,13 @@ def changeset_all_files(
     if not semantic_layer:
         for dbt_root_path in dbt_roots_paths:
             result = process_dbt_project_yml(
-                Path(dbt_root_path), schema_specs, dry_run, exclude_dbt_project_keys, behavior_change, all
+                Path(dbt_root_path),
+                schema_specs,
+                dry_run,
+                exclude_dbt_project_keys,
+                behavior_change,
+                all,
+                skip_rules,
             )
             dbt_project_yml_results.append(result)
             # If not dry run, write the changes immediately before reading the file
@@ -658,7 +677,6 @@ def changeset_all_files(
     dbt_paths = list(dbt_paths_to_node_type.keys())
 
     dbtignore = load_dbtignore(path)
-
     # Computed once for the whole project (rather than per file/path). Reuses the
     # dbt_project.yml content already parsed above instead of re-reading the file,
     # except in semantic_layer mode, where dbt_project.yml isn't processed above.
@@ -684,9 +702,10 @@ def changeset_all_files(
         all,
         unsafe_table_format,
         dbtignore,
+        skip_rules,
     )
     python_results = process_python_files(
-        path, dbt_paths_to_node_type, schema_specs, dry_run, select, behavior_change, all, dbtignore
+        path, dbt_paths_to_node_type, schema_specs, dry_run, select, behavior_change, all, dbtignore, skip_rules
     )
 
     # Process YAML files
@@ -702,6 +721,7 @@ def changeset_all_files(
         semantic_definitions,
         unsafe_table_format,
         dbtignore,
+        skip_rules,
     )
 
     return [*yaml_results, *dbt_project_yml_results], sql_results, python_results

--- a/src/dbt_autofix/refactors/results.py
+++ b/src/dbt_autofix/refactors/results.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, Set
 
 from rich.console import Console
 from ruamel.yaml.comments import CommentedMap
@@ -61,6 +61,7 @@ class YMLRefactorConfig:
     schema_specs: SchemaSpecs
     semantic_definitions: Optional[SemanticDefinitions] = None
     project_has_unsafe_table_format: bool = False
+    skip_rules: Set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -68,6 +69,7 @@ class DbtProjectYMLRefactorConfig:
     schema_specs: SchemaSpecs
     root_path: Path
     exclude_dbt_project_keys: bool = False
+    skip_rules: Set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -75,12 +77,14 @@ class SQLRefactorConfig:
     schema_specs: SchemaSpecs
     node_type: str
     project_has_unsafe_table_format: bool = False
+    skip_rules: Set[str] = field(default_factory=set)
 
 
 @dataclass
 class PythonRefactorConfig:
     schema_specs: SchemaSpecs
     node_type: str
+    skip_rules: Set[str] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +184,8 @@ class YMLRefactorResult:
             current_str=self.refactored_yaml,
         )
         result = func(content, config)
+        if result.rule_name in config.skip_rules:
+            return
         if result.refactored or result.refactor_warnings:
             self.refactors.append(result)
             if result.refactored:
@@ -247,6 +253,8 @@ class SQLRefactorResult:
             current_file_path=self.refactored_file_path,
         )
         result = func(content, config)
+        if result.rule_name in config.skip_rules:
+            return
         self.refactors.append(result)
         if result.refactored:
             self.refactored_content = result.refactored_content
@@ -327,6 +335,8 @@ class PythonRefactorResult:
             current_file_path=self.refactored_file_path,
         )
         result = func(content, config)
+        if result.rule_name in config.skip_rules:
+            return
         self.refactors.append(result)
         if result.refactored:
             self.refactored_content = result.refactored_content

--- a/tests/unit_tests/test_skip_rules.py
+++ b/tests/unit_tests/test_skip_rules.py
@@ -1,0 +1,67 @@
+"""Tests for skipping individual rules via skip_rules / --skip-rule."""
+
+from pathlib import Path
+
+import pytest
+
+from dbt_autofix.refactor import process_dbt_project_yml
+from dbt_autofix.retrieve_schemas import SchemaSpecs
+
+DBT_PROJECT_YML = """\
+name: "demo"
+version: "1.0.0"
+profile: "demo"
+models:
+  demo:
+    +materialized: external
+    +options:
+      partition_by: "country"
+"""
+
+
+@pytest.fixture(scope="module")
+def schema_specs():
+    return SchemaSpecs()
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    (tmp_path / "dbt_project.yml").write_text(DBT_PROJECT_YML)
+    (tmp_path / "models").mkdir()
+    return tmp_path
+
+
+def _rule_names(result) -> set[str]:
+    return {r.rule_name for r in result.refactors if r.refactored}
+
+
+def test_rule_applied_by_default(project_dir, schema_specs):
+    """Without skip_rules, prefix_plus_for_config runs and moves +options to +meta."""
+    result = process_dbt_project_yml(project_dir, schema_specs, dry_run=True)
+
+    assert "prefix_plus_for_config" in _rule_names(result)
+    assert "+meta" in result.refactored_yaml
+
+
+def test_skipped_rule_does_not_run(project_dir, schema_specs):
+    """With the rule skipped, +options is left alone."""
+    result = process_dbt_project_yml(project_dir, schema_specs, dry_run=True, skip_rules={"prefix_plus_for_config"})
+
+    assert "prefix_plus_for_config" not in _rule_names(result)
+    assert "+options" in result.refactored_yaml
+    assert "+meta" not in result.refactored_yaml
+
+
+def test_skipping_one_rule_leaves_others_running(project_dir, schema_specs):
+    """Skipping a rule must not disable the rest of the run."""
+    result = process_dbt_project_yml(project_dir, schema_specs, dry_run=True, skip_rules={"prefix_plus_for_config"})
+
+    assert _rule_names(result), "expected other rules to still apply"
+
+
+def test_unknown_rule_name_is_a_no_op(project_dir, schema_specs):
+    """An unrecognized rule name should not change behaviour."""
+    baseline = process_dbt_project_yml(project_dir, schema_specs, dry_run=True)
+    result = process_dbt_project_yml(project_dir, schema_specs, dry_run=True, skip_rules={"not_a_real_rule"})
+
+    assert _rule_names(result) == _rule_names(baseline)


### PR DESCRIPTION
Related: #324, #373.

### Problem

Rules are currently enforced "all or nothing" which is not always desired.

The issue motivating this change (#412)... a non core dbt project eg. a [dbt-duckdb](https://github.com/duckdb/dbt-duckdb) project has config options that are not in the dbt-core set up. When dbt-autofix runs, it "fixxes" files, but in a way that we don't want.

Letting users turn off a rule is the general answer, and it is useful well beyond this bug.

### Change

A repeatable `--skip-rule` flag, taking the same rule name already shown in the output:

```
Refactored dbt/dbt_project.yml:
  prefix_plus_for_config          <- this name
    Moved unrecognized config '+options' to '+meta'
```

```sh
dbt-autofix deprecations --skip-rule prefix_plus_for_config
```

```yaml
- id: dbt-autofix-fix
  args: [--skip-rule=prefix_plus_for_config]
```

### Implementation

`skip_rules` is added to the four config dataclasses, when set, dbt-autofix will not run that rule... default behaviour is unchanged.

### Verification

Not sure how to verify this change, I added a unit test and verified it works with the dbt-duckdb project that created the issue (both via CLI and the pre-commit hook). I am happy to apply more testing if it makes sense.
