### PR TITLE
Fix plus prefix deprecations false positives

### DIFF
--- a/src/dbt_autofix/jinja.py
+++ b/src/dbt_autofix/jinja.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -6,6 +7,44 @@ import jinja2.nodes
 from dbt_extractor import ExtractionError, py_extract_from_source  # type: ignore
 
 from dbt_autofix._jinja_environment import get_jinja_environment
+
+_HIDDEN_ENV_PREFIXES = ("DBT_ENV_SECRET", "DBT_ENV_PRIVATE")
+
+
+class _UnresolvedEnvVar(Exception):
+    """Raised by env_var when a reference cannot be resolved, to abort the render
+    so resolve_env_vars falls back to the original raw string.
+    """
+
+
+def _env_var(name: str, default: Optional[str] = None) -> str:
+    """env_var callable for the render context. A missing or excluded var with no default
+    raises, which aborts the render so the caller keeps the original raw string.
+    """
+    if name.startswith(_HIDDEN_ENV_PREFIXES):
+        raise _UnresolvedEnvVar(name)
+    if name in os.environ:
+        return os.environ[name]
+    if default is not None:
+        return str(default)
+    raise _UnresolvedEnvVar(name)
+
+
+def resolve_env_vars(raw: Any) -> Any:
+    """Best-effort resolve env_var() calls in a dbt_project.yml value.
+
+    Non-string values and strings without Jinja delimiters are returned
+    unchanged. When a var cannot be resolved, or the template is malformed, the
+    exact original value is returned. For internal decision logic only; the
+    resolved value must not be written back to disk.
+    """
+    if not isinstance(raw, str) or ("{{" not in raw and "{%" not in raw):
+        return raw
+
+    try:
+        return get_jinja_environment().from_string(raw).render(env_var=_env_var)
+    except (_UnresolvedEnvVar, jinja2.TemplateError):
+        return raw
 
 
 def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:

--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 
 import yamllint.config
 
+from dbt_autofix.jinja import resolve_env_vars
 from dbt_autofix.refactors.constants import DBT_PROJECT_CONFIG_MISSPELLINGS
 from dbt_autofix.refactors.results import (
     DbtDeprecationRefactor,
@@ -147,10 +148,13 @@ def rec_check_yaml_path(
                 # Built-in config missing "+"
                 # We cannot add the plus prefix if the value is not scalar in case there is an
                 # overlapping resource path name that we've missed
-                elif k in node_fields.allowed_config_fields_dbt_project and not isinstance(v, dict):
-                    new_k = f"+{k}"
-                    yml_dict[new_k] = v
-                    log_msg = f"Added '+' in front of the nested config '{k}'"
+                elif k in node_fields.allowed_config_fields_dbt_project:
+                    if not isinstance(v, dict):
+                        new_k = f"+{k}"
+                        yml_dict[new_k] = v
+                        log_msg = f"Added '+' in front of the nested config '{k}'"
+                    # We can't say either way if k is meant to be a resource path or a field, so
+                    # we have to stop recursing here
                 # Check if this is a dict value (logical grouping)
                 # Only recurse if it's NOT a valid config key
                 elif isinstance(v, dict):
@@ -282,11 +286,12 @@ def changeset_dbt_project_prefix_plus_for_config(
     all_refactor_logs: List[str] = []
 
     yml_dict = load_yaml(yml_str)
+    resolved_name = resolve_env_vars(yml_dict.get("name"))
 
     for node_type, node_fields in schema_specs.dbtproject_specs_per_node_type.items():
         for k, v in get_dict(yml_dict, node_type).copy().items():
             # check if this is the project name
-            if k == yml_dict["name"]:
+            if k == resolved_name:
                 # Only recurse if v is a dict (should be project configs)
                 if isinstance(v, dict):
                     new_dict, refactor_logs = rec_check_yaml_path(

--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -145,7 +145,9 @@ def rec_check_yaml_path(
                     yml_dict[new_k] = v
                     log_msg = f"Renamed config '{k}' to '{new_k}' (dbt_project.yml expects the hyphenated hook form)"
                 # Built-in config missing "+"
-                elif k in node_fields.allowed_config_fields_dbt_project:
+                # We cannot add the plus prefix if the value is not scalar in case there is an
+                # overlapping resource path name that we've missed
+                elif k in node_fields.allowed_config_fields_dbt_project and not isinstance(v, dict):
                     new_k = f"+{k}"
                     yml_dict[new_k] = v
                     log_msg = f"Added '+' in front of the nested config '{k}'"
@@ -298,8 +300,10 @@ def changeset_dbt_project_prefix_plus_for_config(
             elif k in node_fields.allowed_config_fields_dbt_project or (
                 k.startswith("+") and k[1:] in node_fields.allowed_config_fields_dbt_project
             ):
-                # Config key is valid - if it doesn't have +, add it
-                if not k.startswith("+"):
+                # Config key is valid - if it doesn't have +, add it if the value is scalar
+                # We cannot add the plus prefix if the value is not scalar in case there is an
+                # overlapping resource path name
+                if not k.startswith("+") and not isinstance(v, dict):
                     all_refactor_logs.append(f"Added '+' in front of top level config '{k}'")
                     new_k = f"+{k}"
                     yml_dict[node_type][new_k] = v

--- a/tests/integration_tests/dbt_projects/env_var_group/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/env_var_group/dbt_project.yml
@@ -1,0 +1,10 @@
+name: "{{ env_var('DBT_PROJECT_NAME') }}"
+version: "1.0"
+config-version: 2
+profile: "autofix_group_folder"
+
+models:
+  autofix_group_folder: &project_config
+    group:
+      +schema: "group_folder"
+  autofix_group_folder_qa: *project_config

--- a/tests/integration_tests/dbt_projects/env_var_group/models/group/example.sql
+++ b/tests/integration_tests/dbt_projects/env_var_group/models/group/example.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/integration_tests/dbt_projects/env_var_group_expected.stdout
+++ b/tests/integration_tests/dbt_projects/env_var_group_expected.stdout
@@ -1,0 +1,15 @@
+[
+  {
+    "mode": "complete"
+  },
+  {
+    "file_path": "env_var_group/dbt_project.yml",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "MissingGenericTestArgumentsPropertyDeprecation",
+        "log": "Set flag 'require_generic_test_arguments_property' to 'True' - This will parse the values defined within the `arguments` property of test definition as the test keyword arguments."
+      }
+    ]
+  }
+]

--- a/tests/integration_tests/dbt_projects/env_var_group_expected/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/env_var_group_expected/dbt_project.yml
@@ -1,0 +1,12 @@
+name: "{{ env_var('DBT_PROJECT_NAME') }}"
+version: "1.0"
+config-version: 2
+profile: "autofix_group_folder"
+
+models:
+  autofix_group_folder: &project_config
+    group:
+      +schema: "group_folder"
+  autofix_group_folder_qa: *project_config
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/env_var_group_expected/models/group/example.sql
+++ b/tests/integration_tests/dbt_projects/env_var_group_expected/models/group/example.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project1_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project1_expected.stdout
@@ -76,10 +76,6 @@
       },
       {
         "deprecation": "MissingPlusPrefixDeprecation",
-        "log": "Added '+' in front of the nested config 'meta'"
-      },
-      {
-        "deprecation": "MissingPlusPrefixDeprecation",
         "log": "Added '+' in front of top level config 'enabled'"
       },
       {

--- a/tests/integration_tests/dbt_projects/project1_expected/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project1_expected/dbt_project.yml
@@ -59,7 +59,7 @@ exposures:
   +enabled: true
 tests:
   dbt_autofix_tests:
-    +meta: # meta is a valid test config key - must never be moved to another key
+    meta: # meta is a valid test config key - must never be moved to another key
       owner: data-quality-team
 
 unit-tests:

--- a/tests/integration_tests/test_full_dbt_projects.py
+++ b/tests/integration_tests/test_full_dbt_projects.py
@@ -24,6 +24,9 @@ project_dir_to_behavior_change_mode["project_jinja_templates"] = True
 project_dir_to_semantic_layer_mode = defaultdict(lambda: False)
 project_dir_to_semantic_layer_mode["project_semantic_layer"] = True
 
+project_dir_to_env_vars: defaultdict[str, dict[str, str]] = defaultdict(dict)
+project_dir_to_env_vars["env_var_group"] = {"DBT_PROJECT_NAME": "autofix_group_folder"}
+
 
 def get_project_folders():
     dbt_projects_dir = os.path.join(os.path.dirname(__file__), dbt_projects_dir_name)
@@ -117,9 +120,12 @@ def compare_json_logs(
 
 
 @pytest.mark.parametrize("project_folder", get_project_folders())
-def test_project_refactor(project_folder, request):
+def test_project_refactor(project_folder, request, monkeypatch):
     dbt_projects_dir = os.path.join(os.path.dirname(__file__), dbt_projects_dir_name)
     source_dir = os.path.join(dbt_projects_dir, project_folder)
+
+    for env_name, env_value in project_dir_to_env_vars[project_folder].items():
+        monkeypatch.setenv(env_name, env_value)
 
     # Create a temporary directory for the project
     temp_dir = tempfile.mkdtemp(prefix=f"dbt_autofix_test_{project_folder}_")

--- a/tests/unit_tests/test_env_var_resolution.py
+++ b/tests/unit_tests/test_env_var_resolution.py
@@ -1,0 +1,34 @@
+"""Tests for resolve_env_vars"""
+
+import pytest
+
+from dbt_autofix.jinja import resolve_env_vars
+
+
+@pytest.mark.parametrize(
+    "env,raw,expected",
+    [
+        # Plain string without Jinja is returned unchanged
+        ({}, "my_project", "my_project"),
+        # Non-string values pass through
+        ({}, None, None),
+        ({}, 123, 123),
+        # env_var present resolves to its value
+        ({"DBT_AUTOFIX_TEST_NAME": "my_project"}, "{{ env_var('DBT_AUTOFIX_TEST_NAME') }}", "my_project"),
+        # env_var missing with no default falls back to the raw string
+        ({}, "{{ env_var('DBT_AUTOFIX_TEST_MISSING') }}", "{{ env_var('DBT_AUTOFIX_TEST_MISSING') }}"),
+        # env_var missing with a default resolves to the default
+        ({}, "{{ env_var('DBT_AUTOFIX_TEST_MISSING', 'fallback') }}", "fallback"),
+        # Secret env vars are never resolved, even when set
+        ({"DBT_ENV_SECRET_TOKEN": "shh"}, "{{ env_var('DBT_ENV_SECRET_TOKEN') }}", "{{ env_var('DBT_ENV_SECRET_TOKEN') }}"),
+        # Private env vars are never resolved, even when set
+        ({"DBT_ENV_PRIVATE_X": "hidden"}, "{{ env_var('DBT_ENV_PRIVATE_X') }}", "{{ env_var('DBT_ENV_PRIVATE_X') }}"),
+        # Malformed Jinja falls back to the raw string
+        ({}, "{{ env_var('X' }}", "{{ env_var('X' }}"),
+    ],
+)
+def test_resolve_env_vars(env, raw, expected, monkeypatch):
+    monkeypatch.delenv("DBT_AUTOFIX_TEST_MISSING", raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    assert resolve_env_vars(raw) == expected

--- a/tests/unit_tests/test_env_var_resolution.py
+++ b/tests/unit_tests/test_env_var_resolution.py
@@ -1,4 +1,4 @@
-"""Tests for resolve_env_vars"""
+"""Tests for resolve_env_vars."""
 
 import pytest
 

--- a/tests/unit_tests/test_rec_check_yaml_path.py
+++ b/tests/unit_tests/test_rec_check_yaml_path.py
@@ -679,7 +679,9 @@ def test_user_exact_scenario_from_traceback(models_node_fields, temp_path):
     WHY:    This is the real-world bug that was reported
 
     User had a logical grouping with partition_by (nested dict),
-    cluster_by (list), and tags (list). All should be handled correctly.
+    cluster_by (list), and tags (list). cluster_by and tags should be handled
+    correctly. We cannot prove that partition_by should be plus-prefixed because
+    it could be a resource path.
     """
     input_dict = {
         "example": {
@@ -695,7 +697,7 @@ def test_user_exact_scenario_from_traceback(models_node_fields, temp_path):
 
     expected_output = {
         "example": {
-            "+partition_by": {
+            "partition_by": {
                 "field": "timezone_offset_amt",
                 "data_type": "int64",
                 "range": {"start": -11, "end": 12, "interval": 1},
@@ -708,8 +710,7 @@ def test_user_exact_scenario_from_traceback(models_node_fields, temp_path):
     result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
 
     assert result == expected_output
-    assert len(logs) == 3  # Three configs got + prefix
-    assert any("partition_by" in log for log in logs)
+    assert len(logs) == 2  # Two configs got + prefix
     assert any("cluster_by" in log for log in logs)
     assert any("tags" in log for log in logs)
 
@@ -721,6 +722,8 @@ def test_mixed_config_types_in_logical_grouping(models_node_fields, temp_path):
 
     Note: 'threads' is not a valid config in dbt_project.yml for models,
     so it gets moved to +meta (correct behavior)
+    Also, we can't do this for partition_by because it's a dict, so it's not
+    provably a config over a resource path.
     """
     input_dict = {
         "my_models": {
@@ -735,7 +738,7 @@ def test_mixed_config_types_in_logical_grouping(models_node_fields, temp_path):
     expected_output = {
         "my_models": {
             "+materialized": "table",
-            "+partition_by": {"field": "date", "data_type": "date"},
+            "partition_by": {"field": "date", "data_type": "date"},
             "+cluster_by": ["col1", "col2"],
             "+enabled": True,
             "+meta": {
@@ -747,7 +750,7 @@ def test_mixed_config_types_in_logical_grouping(models_node_fields, temp_path):
     result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
 
     assert result == expected_output
-    assert len(logs) == 5  # 4 configs got + prefix, 1 moved to meta
+    assert len(logs) == 4  # 3 configs got + prefix, 1 moved to meta
 
 
 def test_deeply_nested_with_complex_config_values(models_node_fields, temp_path):
@@ -758,7 +761,7 @@ def test_deeply_nested_with_complex_config_values(models_node_fields, temp_path)
     input_dict = {
         "external_views": {
             "example": {
-                "partition_by": {"field": "date", "data_type": "date", "granularity": "day"},
+                "cluster_by": ["timezone_nm", "zip5_cd", "timezone_offset_adj_amt"],
                 "materialized": "view",
             }
         }
@@ -767,7 +770,7 @@ def test_deeply_nested_with_complex_config_values(models_node_fields, temp_path)
     expected_output = {
         "external_views": {
             "example": {
-                "+partition_by": {"field": "date", "data_type": "date", "granularity": "day"},
+                "+cluster_by": ["timezone_nm", "zip5_cd", "timezone_offset_adj_amt"],
                 "+materialized": "view",
             }
         }
@@ -829,7 +832,7 @@ def test_all_scalar_types_in_one_config(models_node_fields, temp_path):
     OUTPUT: All get + prefix, all value types preserved
     WHY:    Ensure type guard works for all common value types together
 
-    This test focuses on configs with different VALUE types (string, bool, list, dict)
+    This test focuses on configs with different VALUE types (string, bool, list)
     to ensure the type guard preserves all value types correctly.
     """
     input_dict = {
@@ -837,7 +840,6 @@ def test_all_scalar_types_in_one_config(models_node_fields, temp_path):
             "materialized": "table",  # string value
             "enabled": True,  # boolean value
             "tags": ["tag1", "tag2"],  # list value
-            "persist_docs": {"relation": True, "columns": False},  # dict value
         }
     }
 
@@ -846,14 +848,13 @@ def test_all_scalar_types_in_one_config(models_node_fields, temp_path):
             "+materialized": "table",
             "+enabled": True,
             "+tags": ["tag1", "tag2"],
-            "+persist_docs": {"relation": True, "columns": False},
         }
     }
 
     result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
 
     assert result == expected_output
-    assert len(logs) == 4  # All 4 configs got + prefix
+    assert len(logs) == 3  # All 4 configs got + prefix
 
 
 def test_persist_docs_dict_value_not_recursed(models_node_fields, temp_path):
@@ -903,6 +904,8 @@ def test_mixed_valid_configs_with_dict_values(models_node_fields, temp_path):
     WHY:    Comprehensive test for real dbt_project.yml structure
 
     This simulates a real seeds: section from dbt_project.yml
+
+    We must preserve dict values, even though we can't plus-prefix them.
     """
     input_dict = {
         "project": "my_project",  # string config, needs +
@@ -920,17 +923,17 @@ def test_mixed_valid_configs_with_dict_values(models_node_fields, temp_path):
     expected_output = {
         "+project": "my_project",
         "+dataset": "seeds",
-        "+persist_docs": {"relation": True, "columns": True},
-        "+labels": {"application": "analytics", "environment": "prod"},
+        "persist_docs": {"relation": True, "columns": True},
+        "labels": {"application": "analytics", "environment": "prod"},
     }
 
     result, logs = rec_check_yaml_path(input_dict, temp_path, models_node_fields)
 
     assert result == expected_output
-    assert len(logs) == 4  # All 4 configs got + prefix
+    assert len(logs) == 2  # project and dataset got +prefix.
     # Verify no unwanted nesting under +meta
-    assert "+meta" not in result["+persist_docs"]
-    assert "+meta" not in result["+labels"]
+    assert "+meta" not in result["persist_docs"]
+    assert "+meta" not in result["labels"]
 
 
 # =============================================================================

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -1019,7 +1019,7 @@ class TestYamlOutput:
         assert "abc: 123" in yaml_str
 
 
-class TestDbtProjectYAMLPusPrefix:
+class TestDbtProjectYAMLPlusPrefix:
     """Tests for YAML output functions"""
 
     def test_check_project(self, temp_project_dir: Path, schema_specs: SchemaSpecs):
@@ -1058,7 +1058,9 @@ class TestDbtProjectYAMLPusPrefix:
         # Test that output_yaml produces valid YAML
 
         test_data = {"models": {"materialized": "table", "grants": {"materialized": "view"}}}
-        expected_data = {"models": {"+materialized": "table", "+grants": {"materialized": "view"}}}
+        # grants is a valid config with a dict value, but we can't prove that
+        # there isn't a folder named grants
+        expected_data = {"models": {"+materialized": "table", "grants": {"materialized": "view"}}}
 
         new_file = temp_project_dir / "models" / "not_grants" / "my_model.sql"
         new_file.parent.mkdir(parents=True, exist_ok=True)
@@ -1068,7 +1070,7 @@ class TestDbtProjectYAMLPusPrefix:
             test_data, temp_project_dir, schema_specs.dbtproject_specs_per_node_type["models"]
         )
         assert expected_data == new_yml
-        assert len(refactor_logs) == 2
+        assert len(refactor_logs) == 1
 
     def test_check_project_custom_config_not_in_meta(self, temp_project_dir: Path, schema_specs: SchemaSpecs):
         test_data = {


### PR DESCRIPTION
## Description

Resolves https://github.com/dbt-labs/fs/issues/12737.

As I [described in the issue](https://github.com/dbt-labs/fs/issues/12737#issuecomment-5269689492), for completeness we have to implement two changes:

- resolve the project name if it calls `env_var`. This requires a change to `dbt-orc` so autofix has the appropriate environment variables.
- eliminate false positives by only renaming fields if we are really sure that they were meant to be fields. This eliminates the false positive of a resource path with a field's name, but we might miss fields if they have dict values.

Autofix should never _create_ problems, so I'd rather it miss some edge cases here than introduce more parsing errors. The edge case in question could look like this:
```
models:
  my_cool_project:
    quoting:
      database: true
```

Because we can't be absolutely sure that `quoting` isn't meant to be a resource path we can't add the plus-prefix deprecation.

**This means a lot of unit tests had to be rerecorded! We cannot plus-prefix any keys with a dict value unless we add some kind of mapping from every known key to its subkeys.**

For example:
```
    input_dict = {
        "project": "my_project",  # string config, needs +
        "dataset": "seeds",  # string config, needs +
        "persist_docs": {  # dict config, needs +, value preserved
            "relation": True,
            "columns": True,
        },
        "labels": {  # dict config, needs +, value preserved
            "application": "analytics",
            "environment": "prod",
        },
    }

    expected_output = {
        "+project": "my_project",
        "+dataset": "seeds",
        "persist_docs": {"relation": True, "columns": True},
        "labels": {"application": "analytics", "environment": "prod"},
    }
```

We can't plus-prefix `persist_docs` or `labels` anymore because it's possible someone has a folder named `persist_docs` -- or deleted a folder named `persist_docs`. Maybe they have a layout like this:
```
models/
  persist_docs/my_model.sql
  labels/my_model_2.sql
```
and they meant to set `meta` attributes under each. Then the correct autofix behavior would be
```
persist_docs:
  +meta:
    relation: True
    columns: True
labels:
  +meta:
    application: analytics
    environment: prod
```

But we just don't know, so we can't make a decision.

## Type of change

*   [ X] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [X ] Ran `uv run ruff check . --config pyproject.toml`
*   [ X] Ran `uv run ruff format --config pyproject.toml`
*   [ X] Ran `uv run ty check`
*   [ X] If this is a bug fix:
    *   [X ] Updated integration tests with bug repro
    *   [ X] Linked to bug report ticket
*   [ X] Added unit tests if needed
*   [ X] Updated unit tests if needed
*   [ X] Tests passed when run locally
