### PR TITLE
fix: autofix Snowflake Iceberg table format

### DIFF
--- a/src/dbt_autofix/main.py
+++ b/src/dbt_autofix/main.py
@@ -165,11 +165,10 @@ def refactor_yml(
         if not json_output:
             error_console.print("[red]-- Dry run mode, not applying changes --[/red]")
         for changeset in yaml_results:
-            if changeset.refactored:
+            if changeset.refactored or any(r.refactor_warnings for r in changeset.refactors):
                 changeset.print_to_console(json_output)
         for changeset in sql_results:
-            if changeset.refactored:
-                changeset.print_to_console(json_output)
+            changeset.print_to_console(json_output)
         for changeset in python_results:
             if changeset.refactored:
                 changeset.print_to_console(json_output)

--- a/src/dbt_autofix/refactor.py
+++ b/src/dbt_autofix/refactor.py
@@ -87,6 +87,7 @@ def process_yaml_files_except_dbt_project(
     behavior_change: bool = False,
     all: bool = False,
     semantic_definitions: Optional[SemanticDefinitions] = None,
+    project_has_unsafe_table_format: bool = False,
 ) -> List[YMLRefactorResult]:
     """Process all YAML files in the project.
 
@@ -98,12 +99,14 @@ def process_yaml_files_except_dbt_project(
         select: Optional list of paths to select
         behavior_change: Whether to apply fixes that may lead to behavior changes
         all: Whether to run all fixes, including those that may require a behavior change
+        project_has_unsafe_table_format: Whether dbt_project.yml has a non-Iceberg table_format
+            set alongside Iceberg-only model settings, computed once for the whole project
     """
     file_name_to_yaml_results: Dict[str, YMLRefactorResult] = {}
 
     config = YMLRefactorConfig(
         schema_specs=schema_specs,
-        project_has_unsafe_table_format=project_has_unsafe_table_format(root_path),
+        project_has_unsafe_table_format=project_has_unsafe_table_format,
     )
 
     behavior_change_rules: List[Callable] = [
@@ -283,6 +286,7 @@ def process_sql_files(
     select: Optional[List[str]] = None,
     behavior_change: bool = False,
     all: bool = False,
+    project_has_unsafe_table_format: bool = False,
 ) -> List[SQLRefactorResult]:
     """Process all SQL files in the given paths for unmatched endings.
 
@@ -293,6 +297,8 @@ def process_sql_files(
         select: Optional list of paths to select
         behavior_change: Whether to apply fixes that may lead to behavior change
         all: Whether to run all fixes, including those that may require a behavior change
+        project_has_unsafe_table_format: Whether dbt_project.yml has a non-Iceberg table_format
+            set alongside Iceberg-only model settings, computed once for the whole project
 
     Returns:
         List of SQLRefactorResult for each processed file
@@ -322,7 +328,7 @@ def process_sql_files(
         config = SQLRefactorConfig(
             schema_specs=schema_specs,
             node_type=node_type,
-            project_has_unsafe_table_format=project_has_unsafe_table_format(path),
+            project_has_unsafe_table_format=project_has_unsafe_table_format,
         )
 
         sql_files = full_path.glob("**/*.sql")
@@ -612,7 +618,13 @@ def changeset_all_files(
     dbt_paths_to_node_type = get_dbt_files_paths(path, include_packages, include_private_packages)
     dbt_paths = list(dbt_paths_to_node_type.keys())
 
-    sql_results = process_sql_files(path, dbt_paths_to_node_type, schema_specs, dry_run, select, behavior_change, all)
+    # Computed once for the whole project (rather than per file/path) since dbt_project.yml
+    # was just written above, so this reflects its final on-disk state for this run.
+    unsafe_table_format = project_has_unsafe_table_format(path)
+
+    sql_results = process_sql_files(
+        path, dbt_paths_to_node_type, schema_specs, dry_run, select, behavior_change, all, unsafe_table_format
+    )
     python_results = process_python_files(
         path, dbt_paths_to_node_type, schema_specs, dry_run, select, behavior_change, all
     )
@@ -620,7 +632,7 @@ def changeset_all_files(
     # Process YAML files
     semantic_definitions = SemanticDefinitions(path, dbt_paths) if semantic_layer else None
     yaml_results = process_yaml_files_except_dbt_project(
-        path, dbt_paths, schema_specs, dry_run, select, behavior_change, all, semantic_definitions
+        path, dbt_paths, schema_specs, dry_run, select, behavior_change, all, semantic_definitions, unsafe_table_format
     )
 
     return [*yaml_results, *dbt_project_yml_results], sql_results, python_results

--- a/src/dbt_autofix/refactor.py
+++ b/src/dbt_autofix/refactor.py
@@ -618,9 +618,20 @@ def changeset_all_files(
     dbt_paths_to_node_type = get_dbt_files_paths(path, include_packages, include_private_packages)
     dbt_paths = list(dbt_paths_to_node_type.keys())
 
-    # Computed once for the whole project (rather than per file/path) since dbt_project.yml
-    # was just written above, so this reflects its final on-disk state for this run.
-    unsafe_table_format = project_has_unsafe_table_format(path)
+    # Computed once for the whole project (rather than per file/path). Reuses the
+    # dbt_project.yml content already parsed above instead of re-reading the file,
+    # except in semantic_layer mode, where dbt_project.yml isn't processed above.
+    project_yml_result = next((r for r in dbt_project_yml_results if r.file_path == path / "dbt_project.yml"), None)
+    try:
+        if project_yml_result is not None:
+            project_yml_dict = load_yaml(project_yml_result.refactored_yaml)
+        else:
+            project_file = path / "dbt_project.yml"
+            project_yml_dict = load_yaml(project_file.read_text()) if project_file.exists() else None
+        unsafe_table_format = project_has_unsafe_table_format(project_yml_dict)
+    except Exception:
+        # Fail closed: an unparseable dbt_project.yml means we can't tell whether it's safe.
+        unsafe_table_format = True
 
     sql_results = process_sql_files(
         path, dbt_paths_to_node_type, schema_specs, dry_run, select, behavior_change, all, unsafe_table_format

--- a/src/dbt_autofix/refactor.py
+++ b/src/dbt_autofix/refactor.py
@@ -12,6 +12,8 @@ from dbt_autofix.refactors.changesets.dbt_project_yml import (
     changeset_dbt_project_prefix_plus_for_config,
     changeset_dbt_project_remove_deprecated_config,
     changeset_fix_space_after_plus,
+    changeset_iceberg_table_format_project_yml,
+    project_has_unsafe_table_format,
 )
 from dbt_autofix.refactors.changesets.dbt_python import (
     move_custom_config_access_to_meta_python,
@@ -19,6 +21,7 @@ from dbt_autofix.refactors.changesets.dbt_python import (
     rename_python_file_names_with_spaces,
 )
 from dbt_autofix.refactors.changesets.dbt_schema_yml import (
+    changeset_iceberg_table_format_yml,
     changeset_owner_properties_yml_str,
     changeset_refactor_yml_str,
     changeset_remove_duplicate_keys,
@@ -40,6 +43,7 @@ from dbt_autofix.refactors.changesets.dbt_schema_yml_semantic_layer import (
 )
 from dbt_autofix.refactors.changesets.dbt_sql import (
     refactor_custom_configs_to_meta_sql,
+    refactor_iceberg_table_format_sql,
     refactor_static_analysis_sql,
     remove_unmatched_endings,
     rename_sql_file_names_with_spaces,
@@ -66,6 +70,7 @@ from dbt_autofix.retrieve_schemas import (
 from dbt_autofix.semantic_definitions import SemanticDefinitions
 
 error_console = Console(stderr=True)
+
 
 config = """
 rules:
@@ -96,7 +101,10 @@ def process_yaml_files_except_dbt_project(
     """
     file_name_to_yaml_results: Dict[str, YMLRefactorResult] = {}
 
-    config = YMLRefactorConfig(schema_specs=schema_specs)
+    config = YMLRefactorConfig(
+        schema_specs=schema_specs,
+        project_has_unsafe_table_format=project_has_unsafe_table_format(root_path),
+    )
 
     behavior_change_rules: List[Callable] = [
         changeset_replace_non_alpha_underscores_in_name_values,
@@ -112,6 +120,7 @@ def process_yaml_files_except_dbt_project(
         changeset_owner_properties_yml_str,
         changeset_normalize_static_analysis_yml,
     ]
+    behavior_change_rules.append(changeset_iceberg_table_format_yml)
     all_rules: List[Callable] = [*safe_change_rules, *behavior_change_rules]
     changesets = all_rules if all else behavior_change_rules if behavior_change else safe_change_rules
 
@@ -119,7 +128,11 @@ def process_yaml_files_except_dbt_project(
 
     # Override ordered changesets if semantic definitions are provided
     if semantic_definitions:
-        sl_config = YMLRefactorConfig(schema_specs=schema_specs, semantic_definitions=semantic_definitions)
+        sl_config = YMLRefactorConfig(
+            schema_specs=schema_specs,
+            semantic_definitions=semantic_definitions,
+            project_has_unsafe_table_format=config.project_has_unsafe_table_format,
+        )
         # Certain changesets can only be applied after all the other changesets have been applied to all the files
         ordered_changesets = [
             [
@@ -243,6 +256,7 @@ def process_dbt_project_yml(
         changeset_dbt_project_prefix_plus_for_config,
         changeset_normalize_static_analysis_yml,
     ]
+    behavior_change_rules.append(changeset_iceberg_table_format_project_yml)
     all_rules = [*behavior_change_rules, *safe_change_rules]
 
     changesets: List[Callable] = all_rules if all else behavior_change_rules if behavior_change else safe_change_rules
@@ -292,6 +306,7 @@ def process_sql_files(
         refactor_static_analysis_sql,
         move_custom_config_access_to_meta_sql_improved,
     ]
+    behavior_change_rules.append(refactor_iceberg_table_format_sql)
     all_rules = [*behavior_change_rules, *safe_change_rules]
 
     process_sql_file_rules: List[Callable] = (
@@ -304,7 +319,11 @@ def process_sql_files(
             error_console.print(f"Warning: Path {full_path} does not exist", style="yellow")
             continue
 
-        config = SQLRefactorConfig(schema_specs=schema_specs, node_type=node_type)
+        config = SQLRefactorConfig(
+            schema_specs=schema_specs,
+            node_type=node_type,
+            project_has_unsafe_table_format=project_has_unsafe_table_format(path),
+        )
 
         sql_files = full_path.glob("**/*.sql")
         for sql_file in sql_files:
@@ -624,6 +643,7 @@ def apply_changesets(
     for yaml_result in yaml_results:
         if yaml_result.refactored:
             yaml_result.update_yaml_file()
+        if yaml_result.refactored or any(r.refactor_warnings for r in yaml_result.refactors):
             yaml_result.print_to_console(json_output)
 
     # Apply SQL changes

--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 import yamllint.config
 
 from dbt_autofix.refactors.constants import DBT_PROJECT_CONFIG_MISSPELLINGS
+from dbt_autofix.refactors.iceberg_table_format import ICEBERG_ONLY_KEYS, classify_iceberg_table_format
 from dbt_autofix.refactors.results import (
     DbtDeprecationRefactor,
     DbtProjectYMLRefactorConfig,
@@ -22,7 +23,6 @@ rules:
 yaml_config = yamllint.config.YamlLintConfig(config)
 
 
-ICEBERG_ONLY_KEYS = {"external_volume", "base_location_root", "base_location_subpath"}
 _NON_INHERITING_DICT_KEYS = {
     "meta",
     "grants",
@@ -51,7 +51,7 @@ def _iter_iceberg_config_nodes(yml_dict: Any):
         if not isinstance(node, dict):
             return
         keys = {str(key).lstrip("+") for key in node}
-        if keys & ICEBERG_ONLY_KEYS:
+        if keys.intersection(ICEBERG_ONLY_KEYS):
             yield node, inherited_table_format
         effective_table_format = _table_format_of(node, inherited_table_format)
         for key, value in node.items():
@@ -104,14 +104,15 @@ def changeset_iceberg_table_format_project_yml(
 
     for node, inherited_table_format in _iter_iceberg_config_nodes(yml_dict):
         table_format = _table_format_of(node, inherited_table_format)
-        if table_format is None:
+        is_iceberg = table_format is not None and str(table_format).lower() == "iceberg"
+        # dbt_project.yml IS the project config, so it can't be unsafe relative to itself.
+        should_set, warning = classify_iceberg_table_format(table_format, is_iceberg, False)
+        if warning:
+            warnings.append(warning)
+        elif should_set:
             node["+table_format"] = "iceberg"
             changed = True
             logs.append(DbtDeprecationRefactor("Set +table_format=iceberg for Snowflake Iceberg-only model settings"))
-        elif str(table_format).lower() != "iceberg":
-            warnings.append(
-                f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
-            )
 
     return YMLRuleRefactorResult(
         rule_name="set_iceberg_table_format_project_yml",

--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -81,7 +81,12 @@ def project_has_unsafe_table_format(yml_dict: Any) -> bool:
         for key, value in node.items():
             if str(key).lstrip("+") == "table_format" and str(value).lower() != "iceberg":
                 return True
-            if isinstance(value, dict) and contains_non_iceberg(value):
+            if (
+                isinstance(value, dict)
+                and not str(key).startswith("+")
+                and str(key) not in _NON_INHERITING_DICT_KEYS
+                and contains_non_iceberg(value)
+            ):
                 return True
         return False
 

--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -22,18 +22,58 @@ rules:
 yaml_config = yamllint.config.YamlLintConfig(config)
 
 
-def project_has_unsafe_table_format(path: Path) -> bool:
-    project_file = path / "dbt_project.yml"
-    if not project_file.exists():
+ICEBERG_ONLY_KEYS = {"external_volume", "base_location_root", "base_location_subpath"}
+_NON_INHERITING_DICT_KEYS = {
+    "meta",
+    "grants",
+    "persist_docs",
+    "column_types",
+    "pre-hook",
+    "post-hook",
+    "pre_hook",
+    "post_hook",
+}
+
+
+def _table_format_of(node: dict, inherited_table_format: Optional[str]) -> Optional[Any]:
+    table_key = next((key for key in node if str(key).lstrip("+") == "table_format"), None)
+    return node[table_key] if table_key is not None else inherited_table_format
+
+
+def _iter_iceberg_config_nodes(yml_dict: Any):
+    """Yield every ``models``/``snapshots`` config node that sets Iceberg-only settings.
+
+    Each yielded pair is ``(node, table_format)`` where ``table_format`` is the one
+    the node would inherit from its parent, if any.
+    """
+
+    def visit(node: Any, inherited_table_format: Optional[str] = None):
+        if not isinstance(node, dict):
+            return
+        keys = {str(key).lstrip("+") for key in node}
+        if keys & ICEBERG_ONLY_KEYS:
+            yield node, inherited_table_format
+        effective_table_format = _table_format_of(node, inherited_table_format)
+        for key, value in node.items():
+            if isinstance(value, dict) and not str(key).startswith("+") and str(key) not in _NON_INHERITING_DICT_KEYS:
+                yield from visit(value, effective_table_format)
+
+    for resource_type in ("models", "snapshots"):
+        yield from visit(yml_dict.get(resource_type))
+
+
+def project_has_unsafe_table_format(yml_dict: Any) -> bool:
+    """Whether ``dbt_project.yml`` sets a non-Iceberg table_format anywhere under ``models``/``snapshots``.
+
+    A project-level table_format cascades to every model under it, including
+    models declared entirely outside dbt_project.yml (e.g. in SQL/schema-YAML
+    files) that autofix can't see from here. So this check is deliberately
+    project-wide rather than restricted to nodes that also set Iceberg-only
+    settings: model-level autofixes use it to conservatively skip a file whose
+    effective table_format might be inherited from an incompatible project default.
+    """
+    if not isinstance(yml_dict, dict):
         return False
-    try:
-        project = load_yaml(project_file.read_text())
-    except Exception:
-        return True
-    if project is None:
-        return False
-    if not isinstance(project, dict):
-        return True
 
     def contains_non_iceberg(node: Any) -> bool:
         if not isinstance(node, dict):
@@ -45,7 +85,7 @@ def project_has_unsafe_table_format(path: Path) -> bool:
                 return True
         return False
 
-    return any(contains_non_iceberg(project.get(key, {})) for key in ("models", "snapshots"))
+    return any(contains_non_iceberg(yml_dict.get(key, {})) for key in ("models", "snapshots"))
 
 
 def changeset_iceberg_table_format_project_yml(
@@ -61,48 +101,18 @@ def changeset_iceberg_table_format_project_yml(
     logs: List[DbtDeprecationRefactor] = []
     warnings: List[str] = []
     changed = False
-    iceberg_keys = {"external_volume", "base_location_root", "base_location_subpath"}
 
-    def visit(node: Any, inherited_table_format: Optional[str] = None) -> None:
-        nonlocal changed
-        if not isinstance(node, dict):
-            return
-        keys = {str(key).lstrip("+") for key in node}
-        if keys & iceberg_keys:
-            table_key = next((key for key in node if str(key).lstrip("+") == "table_format"), None)
-            table_format = node[table_key] if table_key is not None else inherited_table_format
-            if table_format is None:
-                node["+table_format"] = "iceberg"
-                changed = True
-                logs.append(
-                    DbtDeprecationRefactor("Set +table_format=iceberg for Snowflake Iceberg-only model settings")
-                )
-            elif str(table_format).lower() != "iceberg":
-                warnings.append(
-                    f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
-                )
-        table_key = next((key for key in node if str(key).lstrip("+") == "table_format"), None)
-        effective_table_format = str(node[table_key]).lower() if table_key is not None else inherited_table_format
-        for key, value in node.items():
-            if (
-                isinstance(value, dict)
-                and not str(key).startswith("+")
-                and str(key)
-                not in {
-                    "meta",
-                    "grants",
-                    "persist_docs",
-                    "column_types",
-                    "pre-hook",
-                    "post-hook",
-                    "pre_hook",
-                    "post_hook",
-                }
-            ):
-                visit(value, effective_table_format)
+    for node, inherited_table_format in _iter_iceberg_config_nodes(yml_dict):
+        table_format = _table_format_of(node, inherited_table_format)
+        if table_format is None:
+            node["+table_format"] = "iceberg"
+            changed = True
+            logs.append(DbtDeprecationRefactor("Set +table_format=iceberg for Snowflake Iceberg-only model settings"))
+        elif str(table_format).lower() != "iceberg":
+            warnings.append(
+                f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
+            )
 
-    for resource_type in ("models", "snapshots"):
-        visit(yml_dict.get(resource_type))
     return YMLRuleRefactorResult(
         rule_name="set_iceberg_table_format_project_yml",
         refactored=changed,

--- a/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_project_yml.py
@@ -22,6 +22,97 @@ rules:
 yaml_config = yamllint.config.YamlLintConfig(config)
 
 
+def project_has_unsafe_table_format(path: Path) -> bool:
+    project_file = path / "dbt_project.yml"
+    if not project_file.exists():
+        return False
+    try:
+        project = load_yaml(project_file.read_text())
+    except Exception:
+        return True
+    if project is None:
+        return False
+    if not isinstance(project, dict):
+        return True
+
+    def contains_non_iceberg(node: Any) -> bool:
+        if not isinstance(node, dict):
+            return False
+        for key, value in node.items():
+            if str(key).lstrip("+") == "table_format" and str(value).lower() != "iceberg":
+                return True
+            if isinstance(value, dict) and contains_non_iceberg(value):
+                return True
+        return False
+
+    return any(contains_non_iceberg(project.get(key, {})) for key in ("models", "snapshots"))
+
+
+def changeset_iceberg_table_format_project_yml(
+    content: YMLContent, config: DbtProjectYMLRefactorConfig
+) -> YMLRuleRefactorResult:
+    """Set Iceberg-only model configs to an explicit Iceberg table format.
+
+    Model-level files conservatively skip autofix when any project model config
+    has a non-Iceberg format because this changes materialization behavior.
+    """
+    yml_str = content.current_str
+    yml_dict = load_yaml(yml_str)
+    logs: List[DbtDeprecationRefactor] = []
+    warnings: List[str] = []
+    changed = False
+    iceberg_keys = {"external_volume", "base_location_root", "base_location_subpath"}
+
+    def visit(node: Any, inherited_table_format: Optional[str] = None) -> None:
+        nonlocal changed
+        if not isinstance(node, dict):
+            return
+        keys = {str(key).lstrip("+") for key in node}
+        if keys & iceberg_keys:
+            table_key = next((key for key in node if str(key).lstrip("+") == "table_format"), None)
+            table_format = node[table_key] if table_key is not None else inherited_table_format
+            if table_format is None:
+                node["+table_format"] = "iceberg"
+                changed = True
+                logs.append(
+                    DbtDeprecationRefactor("Set +table_format=iceberg for Snowflake Iceberg-only model settings")
+                )
+            elif str(table_format).lower() != "iceberg":
+                warnings.append(
+                    f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
+                )
+        table_key = next((key for key in node if str(key).lstrip("+") == "table_format"), None)
+        effective_table_format = str(node[table_key]).lower() if table_key is not None else inherited_table_format
+        for key, value in node.items():
+            if (
+                isinstance(value, dict)
+                and not str(key).startswith("+")
+                and str(key)
+                not in {
+                    "meta",
+                    "grants",
+                    "persist_docs",
+                    "column_types",
+                    "pre-hook",
+                    "post-hook",
+                    "pre_hook",
+                    "post_hook",
+                }
+            ):
+                visit(value, effective_table_format)
+
+    for resource_type in ("models", "snapshots"):
+        visit(yml_dict.get(resource_type))
+    return YMLRuleRefactorResult(
+        rule_name="set_iceberg_table_format_project_yml",
+        refactored=changed,
+        refactored_yaml=DbtYAML().dump_to_string(yml_dict) if changed else yml_str,
+        original_yaml=yml_str,
+        deprecation_refactors=logs,
+        refactor_warnings=warnings,
+    )
+
+
 def changeset_dbt_project_remove_deprecated_config(
     content: YMLContent, config: DbtProjectYMLRefactorConfig
 ) -> YMLRuleRefactorResult:

--- a/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
@@ -75,6 +75,54 @@ def changeset_replace_fancy_quotes(content: YMLContent, config: YMLRefactorConfi
     )
 
 
+def changeset_iceberg_table_format_yml(content: YMLContent, config: YMLRefactorConfig) -> YMLRuleRefactorResult:
+    """Set Iceberg-only model settings to an explicit Iceberg table format."""
+    yml_str = content.current_str
+    yml_dict = load_yaml(yml_str)
+    logs: List[DbtDeprecationRefactor] = []
+    warnings: List[str] = []
+    changed = False
+
+    for model in [*get_list(yml_dict, "models"), *get_list(yml_dict, "snapshots")]:
+        if not isinstance(model, CommentedMap):
+            continue
+        model_config = model.get("config")
+        locations = [model]
+        if isinstance(model_config, CommentedMap):
+            locations.insert(0, model_config)
+        iceberg_keys = ("external_volume", "base_location_root", "base_location_subpath")
+        if not any(key in location for location in locations for key in iceberg_keys):
+            continue
+        table_format = next(
+            (location.get("table_format") for location in locations if "table_format" in location), None
+        )
+        if table_format is not None:
+            value = str(table_format).lower()
+            if value != "iceberg":
+                warnings.append(
+                    f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
+                )
+            continue
+        if config.project_has_unsafe_table_format:
+            warnings.append(
+                "Cannot safely autofix Iceberg settings because dbt_project.yml has a non-literal or non-Iceberg table_format"
+            )
+            continue
+        target = model_config if isinstance(model_config, CommentedMap) else model.setdefault("config", CommentedMap())
+        target["table_format"] = "iceberg"
+        changed = True
+        logs.append(DbtDeprecationRefactor("Set table_format=iceberg for Snowflake Iceberg-only model settings"))
+
+    return YMLRuleRefactorResult(
+        rule_name="set_iceberg_table_format_yml",
+        refactored=changed,
+        refactored_yaml=dict_to_yaml_str(yml_dict) if changed else yml_str,
+        original_yaml=yml_str,
+        deprecation_refactors=logs,
+        refactor_warnings=warnings,
+    )
+
+
 def _process_line_fancy_quotes(line: str) -> Tuple[str, bool, List[int]]:
     """Process a single line to handle fancy quotes based on context.
 

--- a/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
@@ -9,6 +9,7 @@ from ruamel.yaml.comments import CommentedMap
 
 from dbt_autofix.deprecations import DeprecationType
 from dbt_autofix.refactors.constants import COMMON_CONFIG_MISSPELLINGS, COMMON_PROPERTY_MISSPELLINGS
+from dbt_autofix.refactors.iceberg_table_format import ICEBERG_ONLY_KEYS, classify_iceberg_table_format
 from dbt_autofix.refactors.results import DbtDeprecationRefactor, YMLContent, YMLRefactorConfig, YMLRuleRefactorResult
 from dbt_autofix.refactors.yml import DbtYAML, dict_to_yaml_str, get_dict, get_list, load_yaml, yaml_config
 from dbt_autofix.retrieve_schemas import SchemaSpecs
@@ -90,23 +91,19 @@ def changeset_iceberg_table_format_yml(content: YMLContent, config: YMLRefactorC
         locations = [model]
         if isinstance(model_config, CommentedMap):
             locations.insert(0, model_config)
-        iceberg_keys = ("external_volume", "base_location_root", "base_location_subpath")
-        if not any(key in location for location in locations for key in iceberg_keys):
+        if not any(key in location for location in locations for key in ICEBERG_ONLY_KEYS):
             continue
         table_format = next(
             (location.get("table_format") for location in locations if "table_format" in location), None
         )
-        if table_format is not None:
-            value = str(table_format).lower()
-            if value != "iceberg":
-                warnings.append(
-                    f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
-                )
+        is_iceberg = table_format is not None and str(table_format).lower() == "iceberg"
+        should_set, warning = classify_iceberg_table_format(
+            table_format, is_iceberg, config.project_has_unsafe_table_format
+        )
+        if warning:
+            warnings.append(warning)
             continue
-        if config.project_has_unsafe_table_format:
-            warnings.append(
-                "Cannot safely autofix Iceberg settings because dbt_project.yml has a non-literal or non-Iceberg table_format"
-            )
+        if not should_set:
             continue
         target = model_config if isinstance(model_config, CommentedMap) else model.setdefault("config", CommentedMap())
         target["table_format"] = "iceberg"

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -483,6 +483,83 @@ def refactor_static_analysis_sql(
     )
 
 
+def refactor_iceberg_table_format_sql(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
+    """Set Snowflake Iceberg model settings to the required explicit table format."""
+    sql_content = content.current_str
+    warnings: List[str] = []
+    refactored_content = sql_content
+    refactored = False
+
+    for start, end, macro_str in reversed(_iter_config_macro_spans(sql_content)):
+        parsed = statically_parse_unrendered_config(macro_str)
+        if not parsed or not any(
+            key in parsed for key in ("external_volume", "base_location_root", "base_location_subpath")
+        ):
+            continue
+        if re.search(r"config\s*\(\s*\{", macro_str) or _contains_dynamic_kwargs(macro_str):
+            warnings.append("Cannot safely autofix config() dictionary or dynamic keyword arguments")
+            continue
+
+        table_format = parsed.get("table_format")
+        try:
+            table_format_value = ast.literal_eval(table_format) if table_format is not None else None
+        except (ValueError, SyntaxError):
+            table_format_value = None
+
+        if isinstance(table_format_value, str):
+            if table_format_value.lower() == "iceberg":
+                continue
+            if table_format_value.lower() == "default":
+                warnings.append("Cannot safely autofix Iceberg settings with explicit table_format=default")
+                continue
+        elif table_format is not None:
+            warnings.append("Cannot safely autofix Iceberg settings with a dynamic table_format")
+            continue
+        elif config.project_has_unsafe_table_format:
+            warnings.append(
+                "Cannot safely autofix Iceberg settings because dbt_project.yml has a non-literal or non-Iceberg table_format"
+            )
+            continue
+
+        refactored_config = dict(parsed)
+        refactored_config["table_format"] = "'iceberg'"
+        source_map = dict(refactored_config)
+        new_config = f"{{{{ config({_serialize_config_macro_call(refactored_config, source_map)}\n) }}}}"
+        refactored_content = refactored_content[:start] + new_config + refactored_content[end:]
+        refactored = True
+
+    return SQLRuleRefactorResult(
+        rule_name="set_iceberg_table_format_sql",
+        refactored=refactored,
+        refactored_content=refactored_content,
+        original_content=sql_content,
+        deprecation_refactors=[
+            DbtDeprecationRefactor(log="Set table_format='iceberg' for Snowflake Iceberg-only model settings")
+        ]
+        if refactored
+        else [],
+        refactor_warnings=warnings,
+    )
+
+
+def _contains_dynamic_kwargs(macro_str: str) -> bool:
+    in_string: Optional[str] = None
+    escaped = False
+    for index, char in enumerate(macro_str):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and in_string:
+            escaped = True
+            continue
+        if char in {"'", '"'}:
+            in_string = None if in_string == char else char if in_string is None else in_string
+            continue
+        if not in_string and macro_str[index : index + 2] == "**":
+            return True
+    return False
+
+
 def _serialize_config_macro_call(config_dict: dict, config_source_map: Optional[Dict[str, str]] = None) -> str:
     """Serialize a config dictionary back to a config macro call string.
 

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -550,7 +550,12 @@ def _contains_dynamic_kwargs(macro_str: str) -> bool:
             in_string = None if in_string == char else char if in_string is None else in_string
             continue
         if not in_string and macro_str[index : index + 2] == "**":
-            return True
+            # Distinguish a `**kwargs` spread from the `**` exponentiation operator: a
+            # spread is always preceded by `(` or `,` (ignoring whitespace), whereas
+            # exponentiation is preceded by an operand (digit, identifier, closing bracket/quote).
+            preceding = macro_str[:index].rstrip()
+            if not preceding or preceding[-1] in "(,":
+                return True
     return False
 
 

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from dbt_autofix.deprecations import DeprecationType
 from dbt_autofix.jinja import statically_parse_unrendered_config
 from dbt_autofix.refactors.constants import COMMON_CONFIG_MISSPELLINGS
+from dbt_autofix.refactors.iceberg_table_format import ICEBERG_ONLY_KEYS, classify_iceberg_table_format
 from dbt_autofix.refactors.results import DbtDeprecationRefactor, SQLContent, SQLRefactorConfig, SQLRuleRefactorResult
 from dbt_autofix.refactors.static_analysis import (
     STATIC_ANALYSIS_DEPRECATION,
@@ -492,9 +493,7 @@ def refactor_iceberg_table_format_sql(content: SQLContent, config: SQLRefactorCo
 
     for start, end, macro_str in reversed(_iter_config_macro_spans(sql_content)):
         parsed = statically_parse_unrendered_config(macro_str)
-        if not parsed or not any(
-            key in parsed for key in ("external_volume", "base_location_root", "base_location_subpath")
-        ):
+        if not parsed or not any(key in parsed for key in ICEBERG_ONLY_KEYS):
             continue
         if re.search(r"config\s*\(\s*\{", macro_str) or _contains_dynamic_kwargs(macro_str):
             warnings.append("Cannot safely autofix config() dictionary or dynamic keyword arguments")
@@ -505,20 +504,15 @@ def refactor_iceberg_table_format_sql(content: SQLContent, config: SQLRefactorCo
             table_format_value = ast.literal_eval(table_format) if table_format is not None else None
         except (ValueError, SyntaxError):
             table_format_value = None
+        is_iceberg = isinstance(table_format_value, str) and table_format_value.lower() == "iceberg"
 
-        if isinstance(table_format_value, str):
-            if table_format_value.lower() == "iceberg":
-                continue
-            if table_format_value.lower() == "default":
-                warnings.append("Cannot safely autofix Iceberg settings with explicit table_format=default")
-                continue
-        elif table_format is not None:
-            warnings.append("Cannot safely autofix Iceberg settings with a dynamic table_format")
+        should_set, warning = classify_iceberg_table_format(
+            table_format, is_iceberg, config.project_has_unsafe_table_format
+        )
+        if warning:
+            warnings.append(warning)
             continue
-        elif config.project_has_unsafe_table_format:
-            warnings.append(
-                "Cannot safely autofix Iceberg settings because dbt_project.yml has a non-literal or non-Iceberg table_format"
-            )
+        if not should_set:
             continue
 
         refactored_config = dict(parsed)

--- a/src/dbt_autofix/refactors/iceberg_table_format.py
+++ b/src/dbt_autofix/refactors/iceberg_table_format.py
@@ -1,0 +1,40 @@
+from typing import Any, Optional, Tuple
+
+# Snowflake config keys that only apply to Iceberg tables.
+ICEBERG_ONLY_KEYS = ("external_volume", "base_location_root", "base_location_subpath")
+
+
+def classify_iceberg_table_format(
+    table_format: Optional[Any],
+    is_iceberg: bool,
+    project_has_unsafe_table_format: bool,
+) -> Tuple[bool, Optional[str]]:
+    """Decide what to do about a config that sets Iceberg-only settings.
+
+    Shared by the SQL, schema-YAML, and dbt_project.yml changesets, which each hold
+    the config in a different shape (a statically-parsed source map, a CommentedMap,
+    or a nested dict with +prefix inheritance) but make the same decision once they
+    know the node's effective ``table_format``.
+
+    Args:
+        table_format: The node's table_format value/source, or None if unset.
+        is_iceberg: Whether table_format is a literal string equal to "iceberg".
+            Ignored when table_format is None.
+        project_has_unsafe_table_format: Whether dbt_project.yml sets a non-Iceberg
+            table_format that this node could inherit; irrelevant once table_format
+            is set here, since it no longer needs to be inherited.
+
+    Returns:
+        ``(should_set_iceberg, warning)``: set table_format=iceberg when
+        ``should_set_iceberg`` is True; otherwise leave the config untouched, and
+        surface ``warning`` (if any) to the user.
+    """
+    if table_format is not None:
+        if is_iceberg:
+            return False, None
+        return False, f"Cannot safely autofix Iceberg settings with explicit or dynamic table_format={table_format}"
+    if project_has_unsafe_table_format:
+        return False, (
+            "Cannot safely autofix Iceberg settings because dbt_project.yml has a non-literal or non-Iceberg table_format"
+        )
+    return True, None

--- a/src/dbt_autofix/refactors/results.py
+++ b/src/dbt_autofix/refactors/results.py
@@ -60,6 +60,7 @@ class PythonContent:
 class YMLRefactorConfig:
     schema_specs: SchemaSpecs
     semantic_definitions: Optional[SemanticDefinitions] = None
+    project_has_unsafe_table_format: bool = False
 
 
 @dataclass
@@ -73,6 +74,7 @@ class DbtProjectYMLRefactorConfig:
 class SQLRefactorConfig:
     schema_specs: SchemaSpecs
     node_type: str
+    project_has_unsafe_table_format: bool = False
 
 
 @dataclass
@@ -93,6 +95,7 @@ class YMLRuleRefactorResult:
     refactored_yaml: str
     original_yaml: str
     deprecation_refactors: list[DbtDeprecationRefactor]
+    refactor_warnings: list[str] = field(default_factory=list)
 
     @property
     def refactor_logs(self):
@@ -102,7 +105,8 @@ class YMLRuleRefactorResult:
         ret_dict = {
             "deprecation_refactors": [
                 deprecation_refactor.to_dict() for deprecation_refactor in self.deprecation_refactors
-            ]
+            ],
+            "warnings": self.refactor_warnings,
         }
         return ret_dict
 
@@ -176,9 +180,10 @@ class YMLRefactorResult:
             current_str=self.refactored_yaml,
         )
         result = func(content, config)
-        if result.refactored:
+        if result.refactored or result.refactor_warnings:
             self.refactors.append(result)
-            self.refactored_yaml = result.refactored_yaml
+            if result.refactored:
+                self.refactored_yaml = result.refactored_yaml
 
     def update_yaml_file(self) -> None:
         """Update the YAML file with the refactored content"""
@@ -187,20 +192,24 @@ class YMLRefactorResult:
         Path(self.file_path).write_text(final_yaml)
 
     def print_to_console(self, json_output: bool = True):
-        if not self.refactored:
+        if not self.refactored and not any(r.refactor_warnings for r in self.refactors):
             return
 
         if json_output:
             flattened_refactors = []
+            flattened_warnings = []
             for refactor in self.refactors:
                 if refactor.refactored:
                     flattened_refactors.extend(refactor.to_dict()["deprecation_refactors"])
+                flattened_warnings.extend(refactor.refactor_warnings)
 
             to_print = {
                 "mode": "dry_run" if self.dry_run else "applied",
                 "file_path": str(self.file_path),
                 "refactors": flattened_refactors,
             }
+            if flattened_warnings:
+                to_print["warnings"] = flattened_warnings
             print(json.dumps(to_print))
             return
 
@@ -209,10 +218,12 @@ class YMLRefactorResult:
             style="green",
         )
         for refactor in self.refactors:
-            if refactor.refactored:
+            if refactor.refactored or refactor.refactor_warnings:
                 console.print(f"  {refactor.rule_name}", style="yellow")
                 for log in refactor.refactor_logs:
                     console.print(f"    {log}")
+                for warning in refactor.refactor_warnings:
+                    console.print(f"    WARNING: {warning}", style="yellow")
 
 
 @dataclass

--- a/tests/unit_tests/test_iceberg_table_format_autofix.py
+++ b/tests/unit_tests/test_iceberg_table_format_autofix.py
@@ -1,0 +1,255 @@
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from typing import cast
+
+import pytest
+from ruamel.yaml.comments import CommentedMap
+
+from dbt_autofix.refactors.changesets.dbt_project_yml import (
+    changeset_iceberg_table_format_project_yml,
+    project_has_unsafe_table_format,
+)
+from dbt_autofix.refactors.changesets.dbt_schema_yml import changeset_iceberg_table_format_yml
+from dbt_autofix.refactors.changesets.dbt_sql import refactor_iceberg_table_format_sql
+from dbt_autofix.refactors.results import (
+    DbtProjectYMLRefactorConfig,
+    SQLContent,
+    SQLRefactorConfig,
+    YMLContent,
+    YMLRefactorConfig,
+    YMLRefactorResult,
+)
+from dbt_autofix.retrieve_schemas import SchemaSpecs
+
+SQL_CONFIG = SQLRefactorConfig(cast(SchemaSpecs, None), "model")
+YML_CONFIG = YMLRefactorConfig(cast(SchemaSpecs, None))
+ICEBERG_SETTINGS = ("external_volume", "base_location_root", "base_location_subpath")
+
+
+def run_sql_rule(content, config=SQL_CONFIG):
+    return refactor_iceberg_table_format_sql(SQLContent(content, content, Path("model.sql")), config)
+
+
+def run_schema_rule(content, config=YML_CONFIG):
+    return changeset_iceberg_table_format_yml(YMLContent(content, cast(CommentedMap, None), content), config)
+
+
+@pytest.mark.parametrize("setting", ICEBERG_SETTINGS)
+def test_sql_adds_iceberg_and_is_idempotent(setting):
+    content = f"{{{{ config({setting}='value') }}}}\nselect 1"
+    result = run_sql_rule(content)
+    assert "table_format='iceberg'" in result.refactored_content
+    rerun = run_sql_rule(result.refactored_content)
+    assert not rerun.refactored
+
+
+def test_sql_adds_iceberg_for_all_settings():
+    content = "{{ config(external_volume='vol', base_location_root='root', base_location_subpath='sub') }}"
+    result = run_sql_rule(content)
+    assert "table_format='iceberg'" in result.refactored_content
+
+
+def test_sql_preserves_iceberg_and_default_conflict():
+    for table_format, changed, warning in [("iceberg", False, False), ("default", False, True)]:
+        content = f"{{{{ config(table_format='{table_format}', external_volume='vol') }}}}"
+        result = run_sql_rule(content)
+        assert result.refactored is changed
+        if warning:
+            assert "Cannot safely" in result.refactor_warnings[0]
+        else:
+            assert result.refactor_warnings == []
+
+
+def test_sql_does_not_warn_for_unrelated_config_shapes():
+    for content in (
+        "{{ config({'sql_header': 'select 2 ** 3'}) }}\nselect 1",
+        "{{ config(sql_header='select 2 ** 3') }}\nselect 1",
+    ):
+        result = run_sql_rule(content)
+        assert result.refactor_warnings == []
+
+
+def test_model_level_autofix_respects_project_default():
+    content = "{{ config(external_volume='vol') }}\nselect 1"
+    sql_result = refactor_iceberg_table_format_sql(
+        SQLContent(content, content, Path("model.sql")),
+        SQLRefactorConfig(cast(SchemaSpecs, None), "model", project_has_unsafe_table_format=True),
+    )
+    assert not sql_result.refactored
+    assert sql_result.refactor_warnings
+
+    yaml_content = """models:
+  - name: model
+    config:
+      external_volume: vol
+"""
+    yaml_result = changeset_iceberg_table_format_yml(
+        YMLContent(yaml_content, cast(CommentedMap, None), yaml_content),
+        YMLRefactorConfig(cast(SchemaSpecs, None), project_has_unsafe_table_format=True),
+    )
+    assert not yaml_result.refactored
+    assert yaml_result.refactor_warnings
+
+
+def test_project_dynamic_table_format_blocks_model_autofix(tmp_path):
+    (tmp_path / "dbt_project.yml").write_text(
+        "models:\n  project:\n    +table_format: \"{{ env_var('TABLE_FORMAT') }}\"\n"
+    )
+    assert project_has_unsafe_table_format(tmp_path)
+
+
+def test_sql_dynamic_kwargs_detection_ignores_string_contents():
+    content = "{{ config(external_volume='vol', sql_header='select 2 ** 3') }}\nselect 1"
+    result = run_sql_rule(content, SQLRefactorConfig(cast(SchemaSpecs, None), "model"))
+    assert result.refactored
+    assert result.refactor_warnings == []
+
+
+def test_sql_dynamic_kwargs_are_not_autofixed():
+    content = "{{ config(external_volume='vol', **model_config) }}\nselect 1"
+    result = run_sql_rule(content)
+    assert not result.refactored
+    assert "dynamic keyword" in result.refactor_warnings[0]
+
+
+def test_malformed_project_config_fails_closed(tmp_path):
+    (tmp_path / "dbt_project.yml").write_text("models: [unclosed")
+    assert project_has_unsafe_table_format(tmp_path)
+
+
+def test_snapshot_yaml_adds_iceberg():
+    content = """snapshots:
+  - name: snapshot
+    config:
+      external_volume: vol
+"""
+    result = run_schema_rule(content)
+    assert "table_format: iceberg" in result.refactored_yaml
+
+
+def test_empty_project_config_does_not_block_model_autofix(tmp_path):
+    (tmp_path / "dbt_project.yml").write_text("")
+    assert not project_has_unsafe_table_format(tmp_path)
+
+
+def test_yaml_warning_is_reported_without_marking_file_changed():
+    content = """models:
+  - name: explicit
+    config:
+      table_format: default
+      external_volume: vol
+"""
+    result = YMLRefactorResult(
+        dry_run=True,
+        file_path=Path("schema.yml"),
+        original_parsed=cast(CommentedMap, None),
+        refactored_yaml=content,
+        original_yaml=content,
+        refactors=[],
+    )
+    result.apply_changeset(changeset_iceberg_table_format_yml, YML_CONFIG)
+    output = StringIO()
+    with redirect_stdout(output):
+        result.print_to_console(json_output=True)
+    assert not result.refactored
+    assert '"refactors": []' in output.getvalue()
+    assert "Cannot safely" in output.getvalue()
+
+
+@pytest.mark.parametrize("setting", ICEBERG_SETTINGS)
+@pytest.mark.parametrize("table_format", [None, "iceberg"])
+def test_schema_yaml_adds_iceberg_in_config(setting, table_format):
+    content = f"""models:
+  - name: implicit
+    config:
+      {setting}: value
+      {"table_format: " + table_format if table_format else ""}
+"""
+    result = run_schema_rule(content)
+    assert result.refactored is (table_format is None)
+    if table_format is None:
+        assert "table_format: iceberg" in result.refactored_yaml
+        rerun = run_schema_rule(result.refactored_yaml)
+        assert not rerun.refactored
+
+
+def test_schema_yaml_preserves_default():
+    content = """models:
+  - name: implicit
+    config:
+      external_volume: vol
+  - name: explicit
+    config:
+      table_format: default
+      external_volume: vol
+"""
+    result = run_schema_rule(content)
+    assert "table_format: iceberg" in result.refactored_yaml
+    assert "table_format: default" in result.refactored_yaml
+    assert "Cannot safely" in result.refactor_warnings[0]
+
+
+def test_schema_yaml_handles_all_iceberg_settings_at_legacy_model_level():
+    content = """models:
+  - name: model
+    external_volume: vol
+    base_location_root: root
+    base_location_subpath: sub
+"""
+    result = run_schema_rule(content)
+    assert "config:\n      table_format: iceberg" in result.refactored_yaml
+
+
+@pytest.mark.parametrize("setting", ICEBERG_SETTINGS)
+@pytest.mark.parametrize("table_format", [None, "iceberg"])
+def test_project_yaml_adds_iceberg_in_deprecated_config_path(setting, table_format):
+    content = f"""models:
+  my_project:
+    +{setting}: value
+    {f"+table_format: {table_format}" if table_format else ""}
+"""
+    result = changeset_iceberg_table_format_project_yml(
+        YMLContent(content, cast(CommentedMap, None), content),
+        DbtProjectYMLRefactorConfig(cast(SchemaSpecs, None), Path(".")),
+    )
+    assert result.refactored is (table_format is None)
+    if table_format is None:
+        assert "+table_format: iceberg" in result.refactored_yaml
+        rerun = changeset_iceberg_table_format_project_yml(
+            YMLContent(result.refactored_yaml, cast(CommentedMap, None), result.refactored_yaml),
+            DbtProjectYMLRefactorConfig(cast(SchemaSpecs, None), Path(".")),
+        )
+        assert not rerun.refactored
+
+
+def test_project_yaml_adds_iceberg_for_all_settings():
+    content = """models:
+  my_project:
+    +external_volume: vol
+    +base_location_root: root
+    +base_location_subpath: sub
+"""
+    result = changeset_iceberg_table_format_project_yml(
+        YMLContent(content, cast(CommentedMap, None), content),
+        DbtProjectYMLRefactorConfig(cast(SchemaSpecs, None), Path(".")),
+    )
+    assert "+table_format: iceberg" in result.refactored_yaml
+
+
+def test_project_yaml_respects_parent_default_and_skips_meta_values():
+    content = """models:
+  my_project:
+    +table_format: default
+    staging:
+      +external_volume: vol
+      +meta:
+        external_volume: note
+"""
+    result = changeset_iceberg_table_format_project_yml(
+        YMLContent(content, cast(CommentedMap, None), content),
+        DbtProjectYMLRefactorConfig(cast(SchemaSpecs, None), Path(".")),
+    )
+    assert not result.refactored
+    assert result.refactor_warnings
+    assert result.refactored_yaml == content

--- a/tests/unit_tests/test_iceberg_table_format_autofix.py
+++ b/tests/unit_tests/test_iceberg_table_format_autofix.py
@@ -20,6 +20,7 @@ from dbt_autofix.refactors.results import (
     YMLRefactorConfig,
     YMLRefactorResult,
 )
+from dbt_autofix.refactors.yml import load_yaml
 from dbt_autofix.retrieve_schemas import SchemaSpecs
 
 SQL_CONFIG = SQLRefactorConfig(cast(SchemaSpecs, None), "model")
@@ -92,11 +93,9 @@ def test_model_level_autofix_respects_project_default():
     assert yaml_result.refactor_warnings
 
 
-def test_project_dynamic_table_format_blocks_model_autofix(tmp_path):
-    (tmp_path / "dbt_project.yml").write_text(
-        "models:\n  project:\n    +table_format: \"{{ env_var('TABLE_FORMAT') }}\"\n"
-    )
-    assert project_has_unsafe_table_format(tmp_path)
+def test_project_dynamic_table_format_blocks_model_autofix():
+    project_yml = load_yaml("models:\n  project:\n    +table_format: \"{{ env_var('TABLE_FORMAT') }}\"\n")
+    assert project_has_unsafe_table_format(project_yml)
 
 
 def test_sql_dynamic_kwargs_detection_ignores_string_contents():
@@ -113,9 +112,12 @@ def test_sql_dynamic_kwargs_are_not_autofixed():
     assert "dynamic keyword" in result.refactor_warnings[0]
 
 
-def test_malformed_project_config_fails_closed(tmp_path):
-    (tmp_path / "dbt_project.yml").write_text("models: [unclosed")
-    assert project_has_unsafe_table_format(tmp_path)
+def test_malformed_project_yaml_raises_so_the_caller_can_fail_closed():
+    # project_has_unsafe_table_format takes an already-parsed dbt_project.yml; a
+    # malformed file fails during that parse, and refactor.py treats the failure
+    # as unsafe (fail closed) rather than silently allowing the autofix.
+    with pytest.raises(Exception):
+        load_yaml("models: [unclosed")
 
 
 def test_snapshot_yaml_adds_iceberg():
@@ -128,9 +130,8 @@ def test_snapshot_yaml_adds_iceberg():
     assert "table_format: iceberg" in result.refactored_yaml
 
 
-def test_empty_project_config_does_not_block_model_autofix(tmp_path):
-    (tmp_path / "dbt_project.yml").write_text("")
-    assert not project_has_unsafe_table_format(tmp_path)
+def test_empty_project_config_does_not_block_model_autofix():
+    assert not project_has_unsafe_table_format(load_yaml(""))
 
 
 def test_yaml_warning_is_reported_without_marking_file_changed():


### PR DESCRIPTION
## Issue

Fixes dbt-labs/fs#12869

The Fusion conformance case uses Snowflake Iceberg-only settings without an explicit `table_format: iceberg`.

The Fusion validation is correct. These settings only apply to Iceberg tables. Removing the validation would make Fusion silently ignore the settings on default tables.

## Why autofix

A project that uses these settings is likely intended to use Iceberg. The autofix makes that intent explicit by adding `table_format: iceberg`.

The fix is in the behavior-change group because it can change the table type.

It does not change an explicit `table_format: iceberg`.
It does not change an explicit `table_format: default`.
It reports a warning when the value is dynamic or the conflict is not safe to resolve.
It is idempotent.

## Changes

- Add the fix for SQL model config.
- Add the fix for schema YAML model and snapshot config.
- Add the fix for `dbt_project.yml` config paths.
- Keep the existing Fusion `dbt1005` validation.
- Report YAML warnings when no file change is made.

## Tests

- `uv run pytest tests/ -q` — 663 passed, 1 xpassed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check .`
- `git diff --check`

## Fusion conformance repro

Using the Snowflake Iceberg repro from the Fusion repository:

1. Ran the new autofix with `--behavior-change`.
2. The autofix added `table_format='iceberg'` to both affected models.
3. Ran the autofix again. The second run made no changes.
4. Built Fusion from `main`.
5. Fusion `parse` passed.
6. Fusion `compile` passed for all 4 models.
7. Fusion `build` reached Snowflake execution. It stopped only because the temporary test credentials were invalid.

The compiled Fusion manifest contains `table_format: iceberg` for both fixed models.