### PR TITLE
fix: ignore boolean schema references during config analysis

### DIFF
--- a/src/dbt_autofix/retrieve_schemas.py
+++ b/src/dbt_autofix/retrieve_schemas.py
@@ -304,7 +304,7 @@ class SchemaSpecs:
                                         ref_name = option["$ref"].split("/")[-1]
                                         if ref_name in schema.get("definitions", {}):
                                             ref_def = schema["definitions"][ref_name]
-                                            if ref_def.get("type") == "object":
+                                            if isinstance(ref_def, dict) and ref_def.get("type") == "object":
                                                 if "properties" in ref_def:
                                                     # Has specific properties defined
                                                     specific_properties[config_name] = set(ref_def["properties"].keys())

--- a/tests/unit_tests/test_retrieve_schemas.py
+++ b/tests/unit_tests/test_retrieve_schemas.py
@@ -1,0 +1,34 @@
+from dbt_autofix.retrieve_schemas import SchemaSpecs
+
+
+def test_dict_config_analysis_ignores_boolean_schema_references(monkeypatch):
+    schema = {
+        "definitions": {
+            "ProjectModelConfig": {
+                "properties": {
+                    "+lifetime": {"anyOf": [{"$ref": "#/definitions/AnyValue"}, {"type": "null"}]},
+                    "+persist_docs": {"anyOf": [{"$ref": "#/definitions/PersistDocs"}, {"type": "null"}]},
+                }
+            },
+            "AnyValue": True,
+            "PersistDocs": {
+                "type": "object",
+                "properties": {"columns": {"type": "boolean"}, "relation": {"type": "boolean"}},
+            },
+        }
+    }
+    schema_specs = object.__new__(SchemaSpecs)
+    schema_specs._dict_config_cache = None
+    schema_specs._schema_version = "test"
+    schema_specs.client = object()
+    monkeypatch.setattr(
+        "dbt_autofix.retrieve_schemas.get_fusion_dbt_project_schema",
+        lambda client, version: schema,
+    )
+
+    analysis = schema_specs.get_dict_config_analysis()
+
+    assert analysis == {
+        "specific_properties": {"persist_docs": {"columns", "relation"}},
+        "open_ended": set(),
+    }


### PR DESCRIPTION
Fixes dbt-labs/fs#13207

##### Changes

- Ignore boolean `$ref` targets during dict config analysis. Fusion schema `v2.0.0-preview.209` uses `AnyValue: true`, which previously raised `AttributeError` before deprecation processing.
- Keep subkey analysis for referenced object schemas and cover both forms in a unit test.

##### Coverage / needs eyes

- 630 unit tests passed; formatting, lint, and type checks passed.
- A `deprecations --dry-run` against `v2.0.0-preview.209` completed successfully.
