### PR TITLE
Write package upgrade output only if dry run not specified

### DIFF
--- a/src/dbt_autofix/packages/dbt_package_text_file.py
+++ b/src/dbt_autofix/packages/dbt_package_text_file.py
@@ -308,7 +308,7 @@ class DbtPackageTextFile:
                     console.print(line.line, style="green")
                 else:
                     console.print(line.line)
-        else:
+        elif not dry_run:
             lines_written = self.write_output_to_file()
             if lines_written == 0 and print_to_console:
                 console.print(f"Error: No output written to {self.file_path.name}")


### PR DESCRIPTION
## Description

Fixes a bug where dry run mode only works if print_to_console is also enabled

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [ ] If this is a bug fix:
    *   [ ] Updated integration tests with bug repro
    *   [ ] Linked to bug report ticket
*   [ ] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
