### PR TITLE
fix: leave nested project config files unchanged in resource paths

### DIFF
--- a/src/dbt_autofix/refactor.py
+++ b/src/dbt_autofix/refactor.py
@@ -52,6 +52,7 @@ from dbt_autofix.refactors.changesets.dbt_sql import (
 from dbt_autofix.refactors.changesets.dbt_sql_improved import (
     move_custom_config_access_to_meta_sql_improved,
 )
+from dbt_autofix.refactors.constants import PROJECT_ROOT_ONLY_YAML_FILENAMES
 from dbt_autofix.refactors.results import (
     DbtProjectYMLRefactorConfig,
     PythonRefactorConfig,
@@ -92,6 +93,9 @@ def process_yaml_files_except_dbt_project(
     dbtignore: Optional[pathspec.PathSpec] = None,
 ) -> List[YMLRefactorResult]:
     """Process all YAML files in the project.
+
+    Project config files (dbt_project.yml and its siblings) are excluded, so only resource
+    properties documents are refactored. See is_project_config_file.
 
     Args:
         path: Project root path
@@ -166,6 +170,9 @@ def process_yaml_files_except_dbt_project(
 
             for yml_file in yaml_files:
                 if skip_file(yml_file, select, dbtignore, root_path):
+                    continue
+
+                if is_project_config_file(yml_file):
                     continue
 
                 if str(yml_file) in file_name_to_yaml_results:
@@ -313,6 +320,20 @@ def skip_file(
             return True
 
     return False
+
+
+def is_project_config_file(yml_file: Path) -> bool:
+    """Whether a YAML file is a dbt project's own config rather than a properties document.
+
+    A reserved filename only counts as project config when it sits next to a dbt_project.yml.
+    Elsewhere (models/packages.yml) it is a properties file that dbt honors, so it must still
+    be processed.
+    """
+    if yml_file.name not in PROJECT_ROOT_ONLY_YAML_FILENAMES:
+        return False
+    # is_file() rather than exists() so a directory named dbt_project.yml does not
+    # suppress a real properties file.
+    return (yml_file.parent / "dbt_project.yml").is_file()
 
 
 def process_sql_files(

--- a/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_schema_yml.py
@@ -432,16 +432,36 @@ def changeset_refactor_yml_str(content: YMLContent, config: YMLRefactorConfig) -
     yml_dict = load_yaml(yml_str)
 
     yml_dict_keys = list(yml_dict.keys())
-    for key in yml_dict_keys:
-        if key not in schema_specs.valid_top_level_yaml_fields:
-            refactored = True
-            deprecation_refactors.append(
-                DbtDeprecationRefactor(
-                    log=f"Removed custom top-level key: '{key}'",
-                    deprecation=DeprecationType.CUSTOM_TOP_LEVEL_KEY_DEPRECATION,
-                )
+    custom_keys = [key for key in yml_dict_keys if key not in schema_specs.valid_top_level_yaml_fields]
+
+    if custom_keys and len(custom_keys) == len(yml_dict_keys):
+        # Every top-level key is unrecognized, so this is not a properties document.
+        # Removing them all would empty the file, so leave it alone and say why.
+        # Return here rather than falling through: "columns" and "tables" are node types
+        # without being valid top-level fields, so the loops below would still rewrite a
+        # file whose only key is one of those, contradicting the warning.
+        return YMLRuleRefactorResult(
+            rule_name="restructure_yaml_keys",
+            refactored=False,
+            refactored_yaml=yml_str,
+            original_yaml=yml_str,
+            deprecation_refactors=[],
+            refactor_warnings=[
+                f"Not a dbt properties file - no recognized top-level keys "
+                f"({', '.join(str(key) for key in custom_keys)}). Left unchanged; move it outside "
+                f"your resource paths or add it to .dbtignore."
+            ],
+        )
+
+    for key in custom_keys:
+        refactored = True
+        deprecation_refactors.append(
+            DbtDeprecationRefactor(
+                log=f"Removed custom top-level key: '{key}'",
+                deprecation=DeprecationType.CUSTOM_TOP_LEVEL_KEY_DEPRECATION,
             )
-            yml_dict.pop(key)
+        )
+        yml_dict.pop(key)
 
     for node_type in schema_specs.yaml_specs_per_node_type:
         if node_type in yml_dict:

--- a/src/dbt_autofix/refactors/constants.py
+++ b/src/dbt_autofix/refactors/constants.py
@@ -15,3 +15,19 @@ COMMON_CONFIG_MISSPELLINGS = {"post-hook": "post_hook", "pre-hook": "pre_hook"}
 # unknown config and moved to +meta, which silently disables a functional hook. Map it back to the
 # hyphenated form instead.
 DBT_PROJECT_CONFIG_MISSPELLINGS = {"pre_hook": "pre-hook", "post_hook": "post-hook"}
+
+# dbt config files that are only meaningful at a project root, never resource properties.
+# Superset of VALID_PACKAGE_YML_NAMES (dbt_package_file.py), which is the inverse notion -
+# the dependency manifests the packages feature parses - and must not be reused here.
+PROJECT_ROOT_ONLY_YAML_FILENAMES: frozenset[str] = frozenset(
+    {
+        "dbt_project.yml",
+        "dependencies.yml",
+        "packages.yml",
+        "package-lock.yml",
+        "catalogs.yml",
+        "vars.yml",
+        "profiles.yml",
+        "selectors.yml",
+    }
+)

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/dbt_project.yml
@@ -1,0 +1,8 @@
+name: "project_nested_project_config"
+version: "1.0.0"
+config-version: 2
+profile: "project_nested_project_config"
+
+model-paths: ["models"]
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/my_model.sql
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/my_model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/packages.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/packages.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: my_model
+    description: "Real model properties in a file that happens to be named packages.yml"
+    materialized: table
+    columns:
+      - name: id
+        description: "Primary key"

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/dbt_project.yml
@@ -1,0 +1,7 @@
+name: inner_project
+version: 2.0.0
+config-version: 2
+profile: inner
+model-paths: ["models"]
+vars:
+  important_var: keep_me

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/dependencies.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/dependencies.yml
@@ -1,0 +1,5 @@
+packages:
+  - package: calogica/dbt_expectations
+    version: 0.10.1
+projects:
+  - name: some_project

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/models/inner_model.sql
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/models/inner_model.sql
@@ -1,0 +1,1 @@
+select 2 as id

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/package-lock.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+sha1_hash: abc123def456

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/packages.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 2.0.0

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/profiles.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/profiles.yml
@@ -1,0 +1,6 @@
+inner:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: ":memory:"

--- a/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/selectors.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config/models/subproject/selectors.yml
@@ -1,0 +1,5 @@
+selectors:
+  - name: nightly
+    definition:
+      method: tag
+      value: nightly

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected.stdout
@@ -1,0 +1,15 @@
+[
+  {
+    "mode": "complete"
+  },
+  {
+    "file_path": "project_nested_project_config/models/packages.yml",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "PropertyMovedToConfigDeprecation",
+        "log": "Model 'my_model' - Field 'materialized' moved under config."
+      }
+    ]
+  }
+]

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/dbt_project.yml
@@ -1,0 +1,8 @@
+name: "project_nested_project_config"
+version: "1.0.0"
+config-version: 2
+profile: "project_nested_project_config"
+
+model-paths: ["models"]
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/my_model.sql
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/my_model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/packages.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/packages.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:
+  - name: my_model
+    description: "Real model properties in a file that happens to be named packages.yml"
+    columns:
+      - name: id
+        description: "Primary key"
+    config:
+      materialized: table

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/dbt_project.yml
@@ -1,0 +1,7 @@
+name: inner_project
+version: 2.0.0
+config-version: 2
+profile: inner
+model-paths: ["models"]
+vars:
+  important_var: keep_me

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/dependencies.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/dependencies.yml
@@ -1,0 +1,5 @@
+packages:
+  - package: calogica/dbt_expectations
+    version: 0.10.1
+projects:
+  - name: some_project

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/models/inner_model.sql
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/models/inner_model.sql
@@ -1,0 +1,1 @@
+select 2 as id

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/package-lock.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+sha1_hash: abc123def456

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/packages.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 2.0.0

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/profiles.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/profiles.yml
@@ -1,0 +1,6 @@
+inner:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: ":memory:"

--- a/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/selectors.yml
+++ b/tests/integration_tests/dbt_projects/project_nested_project_config_expected/models/subproject/selectors.yml
@@ -1,0 +1,5 @@
+selectors:
+  - name: nightly
+    definition:
+      method: tag
+      value: nightly

--- a/tests/integration_tests/dbt_projects/project_root_model_path/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/dbt_project.yml
@@ -1,0 +1,8 @@
+name: "project_root_model_path"
+version: "1.0.0"
+config-version: 2
+profile: "project_root_model_path"
+
+model-paths: ["."]
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_root_model_path/my_model.sql
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/my_model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_root_model_path/package-lock.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+sha1_hash: deadbeef

--- a/tests/integration_tests/dbt_projects/project_root_model_path/packages.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1

--- a/tests/integration_tests/dbt_projects/project_root_model_path/profiles.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/profiles.yml
@@ -1,0 +1,6 @@
+project_root_model_path:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: ":memory:"

--- a/tests/integration_tests/dbt_projects/project_root_model_path/schema.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/schema.yml
@@ -1,0 +1,6 @@
+version: 2
+
+models:
+  - name: my_model
+    description: "A properties file swept up by model-paths: ['.']"
+    materialized: table

--- a/tests/integration_tests/dbt_projects/project_root_model_path/selectors.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path/selectors.yml
@@ -1,0 +1,5 @@
+selectors:
+  - name: nightly
+    definition:
+      method: tag
+      value: nightly

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected.stdout
@@ -1,0 +1,15 @@
+[
+  {
+    "mode": "complete"
+  },
+  {
+    "file_path": "project_root_model_path/schema.yml",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": "PropertyMovedToConfigDeprecation",
+        "log": "Model 'my_model' - Field 'materialized' moved under config."
+      }
+    ]
+  }
+]

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/dbt_project.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/dbt_project.yml
@@ -1,0 +1,8 @@
+name: "project_root_model_path"
+version: "1.0.0"
+config-version: 2
+profile: "project_root_model_path"
+
+model-paths: ["."]
+flags:
+  require_generic_test_arguments_property: true

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/my_model.sql
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/my_model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/package-lock.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+sha1_hash: deadbeef

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/packages.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/profiles.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/profiles.yml
@@ -1,0 +1,6 @@
+project_root_model_path:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: ":memory:"

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/schema.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/schema.yml
@@ -1,0 +1,7 @@
+version: 2
+
+models:
+  - name: my_model
+    description: "A properties file swept up by model-paths: ['.']"
+    config:
+      materialized: table

--- a/tests/integration_tests/dbt_projects/project_root_model_path_expected/selectors.yml
+++ b/tests/integration_tests/dbt_projects/project_root_model_path_expected/selectors.yml
@@ -1,0 +1,5 @@
+selectors:
+  - name: nightly
+    definition:
+      method: tag
+      value: nightly

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -18,6 +18,7 @@ from dbt_autofix.refactor import (
     changeset_remove_extra_tabs,
     changeset_remove_indentation_version,
     changeset_replace_non_alpha_underscores_in_name_values,
+    is_project_config_file,
     load_dbtignore,
     remove_unmatched_endings,
     skip_file,
@@ -28,6 +29,7 @@ from dbt_autofix.refactors.changesets.dbt_schema_yml import (
     changeset_replace_fancy_quotes,
 )
 from dbt_autofix.refactors.changesets.dbt_sql import CONFIG_MACRO_PATTERN, refactor_custom_configs_to_meta_sql
+from dbt_autofix.refactors.constants import PROJECT_ROOT_ONLY_YAML_FILENAMES
 from dbt_autofix.refactors.results import (
     DbtProjectYMLRefactorConfig,
     SQLContent,
@@ -1395,6 +1397,120 @@ class TestSkipFile:
                 dbtignore=dbtignore,
                 root_path=root,
             )
+
+
+class TestIsProjectConfigFile:
+    """Tests for is_project_config_file function"""
+
+    def test_reserved_name_next_to_dbt_project(self):
+        """Test that every reserved name is project config when a dbt_project.yml is its sibling"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            Path(root, "dbt_project.yml").touch()
+            for name in PROJECT_ROOT_ONLY_YAML_FILENAMES:
+                yml_file = root / name
+                yml_file.touch()
+                assert is_project_config_file(yml_file), name
+
+    def test_reserved_name_without_sibling_dbt_project(self):
+        """Test that a reserved name elsewhere is a properties file that must still be processed"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            models = Path(tmpdir, "models")
+            models.mkdir()
+            Path(tmpdir, "dbt_project.yml").touch()
+
+            properties_file = models / "packages.yml"
+            properties_file.touch()
+            assert not is_project_config_file(properties_file)
+
+            nested = models / "nested"
+            nested.mkdir()
+            orphan_file = nested / "dependencies.yml"
+            orphan_file.touch()
+            assert not is_project_config_file(orphan_file)
+
+    def test_dbt_project_yml_itself(self):
+        """Test that a dbt_project.yml is project config, since it is trivially its own sibling"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yml_file = Path(tmpdir, "dbt_project.yml")
+            yml_file.touch()
+            assert is_project_config_file(yml_file)
+
+    def test_non_reserved_name_in_project_root(self):
+        """Test that the rule is filename-based, not 'anything sitting in a project root'"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            Path(root, "dbt_project.yml").touch()
+            yml_file = root / "schema.yml"
+            yml_file.touch()
+            assert not is_project_config_file(yml_file)
+
+    def test_sibling_dbt_project_is_a_directory(self):
+        """Test that a directory named dbt_project.yml does not suppress a real properties file"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            Path(root, "dbt_project.yml").mkdir()
+            yml_file = root / "packages.yml"
+            yml_file.touch()
+            assert not is_project_config_file(yml_file)
+
+
+class TestRefactorYmlStrEmptyGuard:
+    """Tests for the guard that stops custom top-level key removal from emptying a document"""
+
+    def test_all_custom_keys_left_unchanged(self, schema_specs: SchemaSpecs):
+        """Test that a document with no recognized top-level keys is left byte-identical"""
+        input_yaml = """
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+"""
+        result = changeset_refactor_yml_str(_yml(input_yaml), _yml_cfg(schema_specs))
+        assert not result.refactored
+        assert result.refactored_yaml == input_yaml
+        assert len(result.refactor_warnings) == 1
+        assert "no recognized top-level keys" in result.refactor_warnings[0]
+        assert "packages" in result.refactor_warnings[0]
+
+    def test_mixed_keys_still_have_custom_keys_removed(self, schema_specs: SchemaSpecs):
+        """Test that the rule still removes custom keys when a recognized key is also present"""
+        input_yaml = """
+version: 2
+
+models:
+  - name: my_model
+
+some_custom_key: some_value
+"""
+        result = changeset_refactor_yml_str(_yml(input_yaml), _yml_cfg(schema_specs))
+        assert result.refactored
+        assert not result.refactor_warnings
+        assert "Removed custom top-level key: 'some_custom_key'" in result.refactor_logs
+        assert "some_custom_key" not in safe_load(result.refactored_yaml)
+
+    def test_only_recognized_keys_unchanged(self, schema_specs: SchemaSpecs):
+        """Test that a plain properties document is neither refactored nor warned about"""
+        input_yaml = """
+version: 2
+
+models:
+  - name: my_model
+    description: "A test model"
+"""
+        result = changeset_refactor_yml_str(_yml(input_yaml), _yml_cfg(schema_specs))
+        assert not result.refactored
+        assert result.refactored_yaml == input_yaml
+        assert not result.refactor_warnings
+
+    def test_empty_document_is_not_warned_about(self, schema_specs: SchemaSpecs):
+        """Test that a document with no top-level keys at all stays quiet"""
+        input_yaml = """
+# nothing but a comment
+"""
+        result = changeset_refactor_yml_str(_yml(input_yaml), _yml_cfg(schema_specs))
+        assert not result.refactored
+        assert result.refactored_yaml == input_yaml
+        assert not result.refactor_warnings
 
 
 class TestLoadDbtignore:


### PR DESCRIPTION
## Description

Fixes https://github.com/dbt-labs/fs/issues/13272

A `dbt_project.yml` and its siblings can legitimately sit inside a resource path — a
subproject under `models/`, or any project whose `model-paths` includes `"."`. The YAML
changesets treated these as resource properties documents and stripped their top-level
keys, silently emptying a nested project's config.

Guarded in two places, because neither check covers the other:

**`is_project_config_file`** (`refactor.py`) skips reserved filenames — `dbt_project.yml`,
`packages.yml`, `profiles.yml`, and the rest of `PROJECT_ROOT_ONLY_YAML_FILENAMES` — but
only when a `dbt_project.yml` sits beside them. The sibling condition is load-bearing:
`models/packages.yml` with no adjacent project file is a properties document that dbt
honors, so it must still be refactored. The check uses `is_file()` rather than `exists()`
so a *directory* named `dbt_project.yml` cannot suppress a real properties file.

**`changeset_refactor_yml_str`** (`dbt_schema_yml.py`) leaves a file alone when none of its
top-level keys are recognized, which catches non-properties files that don't happen to use
a reserved name. It emits a warning pointing the author at `.dbtignore` instead of
rewriting. It returns early rather than falling through to the node loops, because
`columns` and `tables` are node types *without* being valid top-level fields — so a file
keyed on either one would otherwise still be rewritten while the warning claimed it had
been left unchanged.

Running the new fixture through both guards shows why both are needed:

| file | filename guard | content guard | recognized keys |
| --- | --- | --- | --- |
| `models/packages.yml` | — | — | `version`, `models` |
| `models/subproject/dbt_project.yml` | **blocks** | — | `version` |
| `models/subproject/dependencies.yml` | **blocks** | **blocks** | none |
| `models/subproject/package-lock.yml` | **blocks** | **blocks** | none |
| `models/subproject/packages.yml` | **blocks** | **blocks** | none |
| `models/subproject/profiles.yml` | **blocks** | **blocks** | none |
| `models/subproject/selectors.yml` | **blocks** | **blocks** | none |

The two rows where only one guard fires are the interesting ones. The nested
`dbt_project.yml` needs the filename guard specifically: its `version` key *is* a
recognized top-level field, so the content guard sees one recognized key out of six, takes
the removal path, and strips `name`, `config-version`, `profile`, `model-paths`, and
`vars`. Conversely `models/packages.yml` is deliberately passed by both and refactors
normally (`materialized` → `config`), which a filename-only check would have wrongly
skipped.

Two fixture projects cover the distinct layouts: `project_nested_project_config` (nested
subproject under `models/`) and `project_root_model_path` (`model-paths: ["."]`, so the
glob sweeps the project root and picks up the root's own `packages.yml`, `profiles.yml`,
`selectors.yml`, and `package-lock.yml`).

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [x] If this is a bug fix:
    *   [x] Updated integration tests with bug repro
    *   [x] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [ ] Updated unit tests if needed
*   [x] Tests passed when run locally
