### PR TITLE
fix: resolve repeated config() dict keys last-wins, matching dbt

### DIFF
--- a/src/dbt_autofix/jinja.py
+++ b/src/dbt_autofix/jinja.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import jinja2
 import jinja2.nodes
@@ -8,21 +8,39 @@ from dbt_extractor import ExtractionError, py_extract_from_source  # type: ignor
 from dbt_autofix._jinja_environment import get_jinja_environment
 
 
-def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
-    """Given a string with jinja, extract an unrendered config call.
-    If no config call is present, returns None.
+@dataclass
+class DuplicateConfigKey:
+    """A key defined more than once in a config() dictionary literal."""
+
+    key: str
+    # Source text of the last occurrence - the one dbt resolves the key to
+    kept_value: str
+    # Source text of the earlier occurrences, in source order
+    dropped_values: List[str]
+
+
+def statically_parse_unrendered_config(
+    string: str,
+) -> Tuple[Optional[Dict[str, Any]], List[DuplicateConfigKey]]:
+    """Given a string with jinja, extract an unrendered config call along with the keys that
+    were defined more than once in a config() dictionary literal.
+    If no config call is present, returns (None, []).
 
     For example, given:
     "{{ config(materialized=env_var('DBT_TEST_STATE_MODIFIED')) }}\nselect 1 as id"
-    returns: {'materialized': "Keyword(key='materialized', value=Call(node=Name(name='env_var', ctx='load'), args=[Const(value='DBT_TEST_STATE_MODIFIED')], kwargs=[], dyn_args=None, dyn_kwargs=None))"}
+    returns: ({'materialized': "Keyword(key='materialized', value=Call(node=Name(name='env_var', ctx='load'), args=[Const(value='DBT_TEST_STATE_MODIFIED')], kwargs=[], dyn_args=None, dyn_kwargs=None))"}, [])
 
     No config call:
     "select 1 as id"
-    returns: None
+    returns: (None, [])
+
+    A repeated dict key resolves to its last occurrence, which is what Jinja and Python do
+    when they evaluate the dict literal. Callers that collapse the dictionary into keyword
+    arguments can use the returned entries to tell the user which values were dropped.
     """
     # Return early to avoid creating jinja environemt if no config call in input string
     if "config(" not in string:
-        return None
+        return None, []
 
     env = get_jinja_environment()
 
@@ -39,7 +57,7 @@ def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
     config_func_call = config_func_calls[0] if config_func_calls else None
 
     if not config_func_call:
-        return None
+        return None, []
 
     unrendered_config = {}
 
@@ -48,6 +66,11 @@ def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
         unrendered_config[kwarg.key] = construct_static_kwarg_value(kwarg, string)
 
     # Handle dictionary literal arguments (e.g., config({'pre-hook': 'select 1'}))
+    # Values are resolved positionally through a cursor that only moves forward, so a
+    # repeated key resolves to its last occurrence. jinja2 emits Pair nodes in source order
+    # and keeps every duplicate, so this has to stay a sequential walk over arg.items.
+    dict_value_cursor = 0
+    superseded_values: Dict[str, List[str]] = {}
     for arg in config_func_call.args:
         if isinstance(arg, jinja2.nodes.Dict):
             # Extract key-value pairs from the dictionary
@@ -55,24 +78,44 @@ def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
                 if isinstance(pair.key, jinja2.nodes.Const):
                     key = pair.key.value
                     # Always extract from source to preserve original formatting
-                    value_source = _extract_dict_value_from_source(string, key)
+                    value_source, dict_value_cursor = _extract_dict_value_from_source(string, key, dict_value_cursor)
+                    if key in superseded_values:
+                        superseded_values[key].append(unrendered_config[key])
+                    else:
+                        superseded_values[key] = []
                     unrendered_config[key] = value_source
 
-    return unrendered_config if unrendered_config else None
+    duplicate_keys = [
+        DuplicateConfigKey(key=key, kept_value=unrendered_config[key], dropped_values=dropped_values)
+        for key, dropped_values in superseded_values.items()
+        if dropped_values
+    ]
+
+    return (unrendered_config if unrendered_config else None), duplicate_keys
 
 
-def _extract_dict_value_from_source(source_string: str, key: str) -> str:
+def _extract_dict_value_from_source(source_string: str, key: str, search_from: int = 0) -> Tuple[str, int]:
     """Extract a dictionary value from source string.
 
     This is used for dictionary literal arguments like config({'key': value}).
     Handles both single and double quotes for keys.
+
+    Args:
+        source_string: Original source string containing the config macro call
+        key: Dictionary key whose value should be extracted
+        search_from: Offset to start searching from, so a repeated key resolves to its
+            next occurrence rather than always to the first one
+
+    Returns:
+        Tuple of the value's source code and the offset just past it. An unresolvable key
+        returns ``search_from`` unchanged, so the caller's cursor never moves backwards.
     """
     import re
 
     # Find the config( and the dictionary
     config_match = re.search(r"\{\{\s*config\s*\(\s*\{", source_string)
     if not config_match:
-        return str(key)  # Fallback
+        return str(key), search_from  # Fallback
 
     # Try to find the key with both single and double quotes
     # First try with the format as it appears in the source (single quotes by default from repr)
@@ -81,24 +124,54 @@ def _extract_dict_value_from_source(source_string: str, key: str) -> str:
         rf'"{re.escape(key)}"\s*:\s*',  # "key": value
     ]
 
-    key_match = None
-    for pattern in key_patterns:
-        key_pattern = re.compile(pattern, re.MULTILINE)
-        key_match = key_pattern.search(source_string, config_match.end())
-        if key_match:
-            break
+    dict_start = config_match.end()
 
-    if key_match:
-        value_start = key_match.end()
-        extractor = _SourceCodeExtractor(source_string)
-        # Stop at comma or closing brace
-        source_value = extractor.extract_until_delimiter(value_start, delimiters=(",", "}"))
-        # Clean up: strip any trailing delimiters that shouldn't be included
-        source_value = source_value.rstrip(",}")
-        if source_value:
-            return source_value
+    resolved = _resolve_dict_value_at_or_after(source_string, key_patterns, max(dict_start, search_from))
+    if resolved:
+        return resolved
 
-    return repr(key)  # Fallback
+    # The cursor can only sit past a real occurrence of the key if an earlier value was
+    # mis-parsed. Re-scan the whole dictionary so that a miss degrades to binding the first
+    # occurrence - what this function did before the cursor existed - instead of fabricating a
+    # value. Report the cursor unchanged so it can never move backwards.
+    if search_from > dict_start:
+        resolved = _resolve_dict_value_at_or_after(source_string, key_patterns, dict_start)
+        if resolved:
+            return resolved[0], search_from
+
+    return repr(key), search_from  # Fallback
+
+
+def _resolve_dict_value_at_or_after(
+    source_string: str, key_patterns: List[str], from_pos: int
+) -> Optional[Tuple[str, int]]:
+    """Resolve the earliest key-pattern match at or after ``from_pos`` to its value.
+
+    Both quoting styles have to be considered together: taking the first *pattern* that
+    matches anywhere would bind a key to a later, differently quoted occurrence and skip the
+    one in between.
+
+    Returns:
+        Tuple of the value's source code and the offset just past it, or None if no pattern
+        matched or the match yielded an empty value.
+    """
+    import re
+
+    matches = [
+        match
+        for match in (re.compile(pattern, re.MULTILINE).search(source_string, from_pos) for pattern in key_patterns)
+        if match
+    ]
+    if not matches:
+        return None
+
+    key_match = min(matches, key=lambda match: match.start())
+    extractor = _SourceCodeExtractor(source_string)
+    # Stop at comma or closing brace
+    source_value, value_end = extractor.extract_until_delimiter(key_match.end(), delimiters=(",", "}"))
+    # Clean up: strip any trailing delimiters that shouldn't be included
+    source_value = source_value.rstrip(",}")
+    return (source_value, value_end) if source_value else None
 
 
 class _SourceCodeExtractor:
@@ -116,7 +189,7 @@ class _SourceCodeExtractor:
         self.pos = 0
         self.length = len(source)
 
-    def extract_until_delimiter(self, start_pos: int, delimiters: tuple = (",", ")")) -> str:
+    def extract_until_delimiter(self, start_pos: int, delimiters: tuple = (",", ")")) -> Tuple[str, int]:
         """Extract source code from start_pos until a top-level delimiter is found.
 
         Args:
@@ -124,11 +197,14 @@ class _SourceCodeExtractor:
             delimiters: Tuple of delimiter characters to stop at (when at nesting level 0)
 
         Returns:
-            Extracted source code string, stripped of leading/trailing whitespace
+            Tuple of the extracted source code, stripped of leading/trailing whitespace, and
+            the offset of the top-level delimiter that ended it - or the end of the source if
+            no delimiter was found. Callers scanning for repeated keys use the offset to
+            resume past the value they just read.
 
         Example:
-            For "func(a, b), x" with start_pos=5 and delimiters=(',',):
-            Returns "a, b)"  (stops at the comma after the closing paren)
+            For "config(key=func(a, b), x)" with start_pos=11 and delimiters=(',', ')'):
+            Returns ("func(a, b)", 21)  (stops at the comma after the closing paren)
         """
         paren_count = 0
         bracket_count = 0
@@ -171,7 +247,7 @@ class _SourceCodeExtractor:
                     end_pos = i
                     break
 
-        return self.source[start_pos:end_pos].strip().rstrip(",")
+        return self.source[start_pos:end_pos].strip().rstrip(","), end_pos
 
 
 def construct_static_kwarg_value(kwarg, source_string: str) -> str:
@@ -209,7 +285,7 @@ def construct_static_kwarg_value(kwarg, source_string: str) -> str:
         if key_match:
             value_start = key_match.end()
             extractor = _SourceCodeExtractor(source_string)
-            source_value = extractor.extract_until_delimiter(value_start, delimiters=(",", ")"))
+            source_value, _ = extractor.extract_until_delimiter(value_start, delimiters=(",", ")"))
 
             # Return the extracted source if we got something
             if source_value:

--- a/src/dbt_autofix/refactors/changesets/dbt_sql.py
+++ b/src/dbt_autofix/refactors/changesets/dbt_sql.py
@@ -4,7 +4,10 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 from dbt_autofix.deprecations import DeprecationType
-from dbt_autofix.jinja import statically_parse_unrendered_config
+from dbt_autofix.jinja import (
+    DuplicateConfigKey,
+    statically_parse_unrendered_config,
+)
 from dbt_autofix.refactors.constants import COMMON_CONFIG_MISSPELLINGS
 from dbt_autofix.refactors.iceberg_table_format import ICEBERG_ONLY_KEYS, classify_iceberg_table_format
 from dbt_autofix.refactors.results import DbtDeprecationRefactor, SQLContent, SQLRefactorConfig, SQLRuleRefactorResult
@@ -248,6 +251,38 @@ def meta_transform_value(v):
         return repr(v)
 
 
+_DUPLICATE_VALUE_SUMMARY_LIMIT = 60
+
+
+def _summarize_source_value(value: str) -> str:
+    """Collapse a config value's source text to a single short line for logging."""
+    collapsed = " ".join(value.split())
+    if len(collapsed) > _DUPLICATE_VALUE_SUMMARY_LIMIT:
+        return f"{collapsed[:_DUPLICATE_VALUE_SUMMARY_LIMIT]}..."
+    return collapsed
+
+
+def _duplicate_key_refactors(duplicates: List[DuplicateConfigKey]) -> List[DbtDeprecationRefactor]:
+    """Note every config key that was defined more than once in a config() dictionary."""
+    refactors: List[DbtDeprecationRefactor] = []
+    for duplicate in duplicates:
+        dropped_count = len(duplicate.dropped_values)
+        dropped_values = ", ".join(_summarize_source_value(value) for value in duplicate.dropped_values)
+        refactors.append(
+            DbtDeprecationRefactor(
+                log=(
+                    f"Config key '{duplicate.key}' was defined {dropped_count + 1} times in the config() "
+                    f"dictionary; kept the last value ({_summarize_source_value(duplicate.kept_value)}) "
+                    f"and dropped the earlier {'ones' if dropped_count > 1 else 'one'} ({dropped_values}), "
+                    "which is how dbt resolves a repeated key."
+                ),
+                # dbt resolves a repeated dictionary key silently, so there is no deprecation for it
+                deprecation=None,
+            )
+        )
+    return refactors
+
+
 def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactorConfig) -> SQLRuleRefactorResult:
     """Move custom configs to meta in SQL files."""
     sql_content = content.current_str
@@ -259,6 +294,7 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
 
     # Always use static parsing to handle configs with or without Jinja
     config_macro_str = ""
+    duplicate_config_keys: List[DuplicateConfigKey] = []
     config_source_map: Dict[str, str] = {}
     original_sql_configs: Dict[str, Any] = {}
 
@@ -269,7 +305,8 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
 
         if config_macro_str:
             # Use static parsing to get source code (handles Jinja without rendering)
-            original_statically_parsed_config = statically_parse_unrendered_config(config_macro_str) or {}
+            parsed_config, duplicate_config_keys = statically_parse_unrendered_config(config_macro_str)
+            original_statically_parsed_config = parsed_config or {}
 
             if original_statically_parsed_config:
                 # Use parsed config values as both data and source map
@@ -360,6 +397,8 @@ def refactor_custom_configs_to_meta_sql(content: SQLContent, config: SQLRefactor
     if refactored_sql_configs != original_sql_configs:
         refactored = True
 
+        deprecation_refactors.extend(_duplicate_key_refactors(duplicate_config_keys))
+
         # Generate deprecation refactors
         for renamed_config in renamed_configs:
             deprecation_refactors.append(
@@ -449,7 +488,7 @@ def refactor_static_analysis_sql(
     refactored_content = sql_content
     # Process macros from last to first so earlier spans keep their positions after splicing.
     for start, end, macro_str in reversed(_iter_config_macro_spans(sql_content)):
-        parsed_config = statically_parse_unrendered_config(macro_str)
+        parsed_config, duplicate_config_keys = statically_parse_unrendered_config(macro_str)
         if not parsed_config or STATIC_ANALYSIS_KEY not in parsed_config:
             continue
 
@@ -466,14 +505,16 @@ def refactor_static_analysis_sql(
         new_macro = f"{{{{ config({new_config_str}\n) }}}}"
         refactored_content = refactored_content[:start] + new_macro + refactored_content[end:]
 
-        deprecation_refactors.insert(
-            0,
+        # Spans are walked in reverse, so splice this span's entries as a unit to keep them
+        # in source order and keep the duplicate notes next to their own span.
+        deprecation_refactors[0:0] = [
+            *_duplicate_key_refactors(duplicate_config_keys),
             DbtDeprecationRefactor(
                 log=f"Converted static_analysis={original_source} to static_analysis='{new_enum}' "
                 "(static_analysis must be a Fusion enum value)",
                 deprecation=STATIC_ANALYSIS_DEPRECATION,
             ),
-        )
+        ]
 
     return SQLRuleRefactorResult(
         rule_name="normalize_static_analysis_sql",
@@ -492,7 +533,7 @@ def refactor_iceberg_table_format_sql(content: SQLContent, config: SQLRefactorCo
     refactored = False
 
     for start, end, macro_str in reversed(_iter_config_macro_spans(sql_content)):
-        parsed = statically_parse_unrendered_config(macro_str)
+        parsed, _ = statically_parse_unrendered_config(macro_str)
         if not parsed or not any(key in parsed for key in ICEBERG_ONLY_KEYS):
             continue
         if re.search(r"config\s*\(\s*\{", macro_str) or _contains_dynamic_kwargs(macro_str):

--- a/tests/integration_tests/dbt_projects/project_custom_key_in_config/models/duplicate_dict_keys.sql
+++ b/tests/integration_tests/dbt_projects/project_custom_key_in_config/models/duplicate_dict_keys.sql
@@ -1,0 +1,5 @@
+-- the hook rename collapses the config() dict; the repeated 'tags' key must keep its last
+-- value, which is the one dbt itself resolves to
+{{ config({"materialized": "table", "tags": "mapping_tables", "post-hook": ["select 1"], "tags": ["weekly"]}) }}
+
+select 1 as id

--- a/tests/integration_tests/dbt_projects/project_custom_key_in_config_expected.stdout
+++ b/tests/integration_tests/dbt_projects/project_custom_key_in_config_expected.stdout
@@ -18,6 +18,21 @@
     "warnings": []
   },
   {
+    "file_path": "project_custom_key_in_config/models/duplicate_dict_keys.sql",
+    "mode": "applied",
+    "refactors": [
+      {
+        "deprecation": null,
+        "log": "Config key 'tags' was defined 2 times in the config() dictionary; kept the last value ([\"weekly\"]) and dropped the earlier one (\"mapping_tables\"), which is how dbt resolves a repeated key."
+      },
+      {
+        "deprecation": "CustomKeyInConfigDeprecation",
+        "log": "Config 'post-hook' is a common misspelling of 'post_hook', it has been renamed."
+      }
+    ],
+    "warnings": []
+  },
+  {
     "file_path": "project_custom_key_in_config/models/models.yaml",
     "mode": "applied",
     "refactors": [

--- a/tests/integration_tests/dbt_projects/project_custom_key_in_config_expected/models/duplicate_dict_keys.sql
+++ b/tests/integration_tests/dbt_projects/project_custom_key_in_config_expected/models/duplicate_dict_keys.sql
@@ -1,0 +1,9 @@
+-- the hook rename collapses the config() dict; the repeated 'tags' key must keep its last
+-- value, which is the one dbt itself resolves to
+{{ config(
+    materialized="table", 
+    tags=["weekly"], 
+    post_hook=["select 1"]
+) }}
+
+select 1 as id

--- a/tests/unit_tests/test_jinja.py
+++ b/tests/unit_tests/test_jinja.py
@@ -4,6 +4,7 @@ import pytest
 
 from dbt_autofix._jinja_environment import get_jinja_environment
 from dbt_autofix.jinja import (
+    DuplicateConfigKey,
     _SourceCodeExtractor,
     construct_static_kwarg_value,
     statically_parse_unrendered_config,
@@ -99,6 +100,33 @@ from dbt_autofix.jinja import (
             '{{ config(custom_path=target.schema + "/" + var("folder")) }}',
             {"custom_path": 'target.schema + "/" + var("folder")'},
         ),
+        # A repeated dict key resolves to its last occurrence, like Jinja and Python do
+        (
+            '{{ config({"materialized": "table", "tags": "first", "post-hook": ["select 1"], "tags": ["weekly"]}) }}',
+            {"materialized": '"table"', "tags": '["weekly"]', "post-hook": '["select 1"]'},
+        ),
+        # Three occurrences, with the middle one quoted differently, resolve to the third value
+        (
+            '{{ config({"tags": "one", \'tags\': "two", "tags": "three", "post-hook": ["select 1"]}) }}',
+            {"tags": '"three"', "post-hook": '["select 1"]'},
+        ),
+        # Quote style must not decide which occurrence wins: the last one does, whichever style
+        # it uses. Values span lines and the last pair has a trailing comma, so the scan has to
+        # resume past a multi-line value.
+        (
+            '{{ config({\n  "materialized": "table",\n  "tags": "first",\n  \'tags\': [\n    "weekly",\n  ],\n  "post-hook": ["select 1"],\n}) }}',
+            {"materialized": '"table"', "tags": '[\n    "weekly",\n  ]', "post-hook": '["select 1"]'},
+        ),
+        # Repeated key whose values are Jinja expressions keeps the last expression
+        (
+            "{{ config({'materialized': 'table', 'tags': env_var('TAG_A'), 'tags': env_var('TAG_B')}) }}",
+            {"materialized": "'table'", "tags": "env_var('TAG_B')"},
+        ),
+        # A key name appearing inside a value does not shadow the real pair
+        (
+            "{{ config({'sql': \"'tags': 'decoy'\", 'tags': 'real'}) }}",
+            {"sql": "\"'tags': 'decoy'\"", "tags": "'real'"},
+        ),
     ],
 )
 def test_statically_parse_unrendered_config(input_string, expected_output):
@@ -109,8 +137,38 @@ def test_statically_parse_unrendered_config(input_string, expected_output):
     dbt will still evaluate them at runtime because the entire config() block
     is a Jinja expression.
     """
-    result = statically_parse_unrendered_config(input_string)
+    result, _ = statically_parse_unrendered_config(input_string)
     assert result == expected_output
+
+
+def test_statically_parse_unrendered_config_duplicate_keys():
+    """Repeated dict keys are reported alongside the parsed config, in source order."""
+    config, duplicates = statically_parse_unrendered_config(
+        '{{ config({"tags": "one", \'tags\': "two", "tags": "three"}) }}'
+    )
+    assert config == {"tags": '"three"'}
+    assert duplicates == [DuplicateConfigKey(key="tags", kept_value='"three"', dropped_values=['"one"', '"two"'])]
+
+    # A dict literal without repeats reports nothing, and keyword arguments cannot repeat a key
+    # at all, so that path never reports duplicates either
+    _, no_duplicates = statically_parse_unrendered_config('{{ config({"materialized": "table", "tags": ["weekly"]}) }}')
+    assert no_duplicates == []
+    _, kwargs_duplicates = statically_parse_unrendered_config("{{ config(materialized='table', tags=['weekly']) }}")
+    assert kwargs_duplicates == []
+
+
+def test_unresolvable_key_does_not_fabricate_for_following_keys():
+    """A mis-parsed earlier value must not cascade a fabricated value onto later keys.
+
+    The pair with a non-Const key is skipped by the caller loop, so the cursor never advances
+    past its value and the decoy inside it is the earliest match for 'tags'. The keys after it
+    must still resolve rather than falling through to the key-name fallback.
+    """
+    result, _ = statically_parse_unrendered_config(
+        "{{ config({var('k'): \"see 'tags': decoy\", 'tags': 'real', 'post-hook': ['x']}) }}"
+    )
+    assert result is not None
+    assert result["post-hook"] == "['x']"
 
 
 @pytest.mark.parametrize(
@@ -154,7 +212,7 @@ def test_statically_parse_unrendered_config(input_string, expected_output):
 def test_source_code_extractor(source, start_pos, delimiters, expected_output):
     """Test _SourceCodeExtractor.extract_until_delimiter with various inputs."""
     extractor = _SourceCodeExtractor(source)
-    result = extractor.extract_until_delimiter(start_pos, delimiters=delimiters)
+    result, _ = extractor.extract_until_delimiter(start_pos, delimiters=delimiters)
     assert result == expected_output
 
 
@@ -167,7 +225,7 @@ def test_source_code_extractor_multiline():
     extractor = _SourceCodeExtractor(source)
     # Start after "key="
     start = source.index("key='") + 4
-    result = extractor.extract_until_delimiter(start, delimiters=(",", ")"))
+    result, _ = extractor.extract_until_delimiter(start, delimiters=(",", ")"))
     assert "'value'" in result.strip()
 
 
@@ -299,7 +357,7 @@ def test_construct_static_kwarg_value_fallback():
 )
 def test_integration_full_workflow(config_str, expected_keys, expected_values):
     """Integration tests for the full workflow from parsing to extraction."""
-    result = statically_parse_unrendered_config(config_str)
+    result, _ = statically_parse_unrendered_config(config_str)
 
     assert result is not None
     assert set(result.keys()) == expected_keys
@@ -328,7 +386,7 @@ def test_construct_static_kwarg_value_very_long_value():
     config_str = f"{{{{ config(post_hook='{long_sql}') }}}}"
 
     # Step 1: Extract the config
-    result = statically_parse_unrendered_config(config_str)
+    result, _ = statically_parse_unrendered_config(config_str)
 
     assert result is not None
     assert "post_hook" in result

--- a/tests/unit_tests/test_refactor.py
+++ b/tests/unit_tests/test_refactor.py
@@ -3109,3 +3109,64 @@ select 1 as id
         assert "on_column" in result.deprecation_refactors[0].log
         assert "nugget" in result.deprecation_refactors[0].log
         assert "meta" in result.deprecation_refactors[0].log
+
+    @pytest.mark.parametrize(
+        "trigger_config,expected_trigger_log",
+        [
+            # A hook rename collapses the dict into keyword arguments...
+            (
+                '"post-hook": ["select 1"]',
+                "Config 'post-hook' is a common misspelling of 'post_hook', it has been renamed.",
+            ),
+            # ...and so does a custom config moving to meta, so the fix is not hook-specific
+            ('"my_custom_thing": "abc"', "Moved custom config ['my_custom_thing'] to 'meta'"),
+        ],
+    )
+    def test_repeated_dict_key_keeps_last_value(
+        self, schema_specs: SchemaSpecs, trigger_config: str, expected_trigger_log: str
+    ):
+        """A repeated key in a config() dict resolves to its last occurrence, as dbt does."""
+        sql_content = (
+            f'{{{{ config({{"materialized": "table", "tags": "mapping_tables", '
+            f'{trigger_config}, "tags": ["weekly"]}}) }}}}\nselect 1 as id\n'
+        )
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert result.refactored
+        assert 'tags=["weekly"]' in result.refactored_content
+        assert "mapping_tables" not in result.refactored_content
+        assert result.refactor_logs == [
+            "Config key 'tags' was defined 2 times in the config() dictionary; "
+            'kept the last value (["weekly"]) and dropped the earlier one ("mapping_tables"), '
+            "which is how dbt resolves a repeated key.",
+            expected_trigger_log,
+        ]
+        # This is autofix preserving dbt's own resolution, not a dbt deprecation
+        assert result.deprecation_refactors[0].deprecation is None
+
+    def test_dict_key_repeated_three_times(self, schema_specs: SchemaSpecs):
+        """More than one dropped value is reported as a list, and the third value survives."""
+        sql_content = (
+            '{{ config({"tags": "one", "tags": "two", "tags": "three", "my_custom_thing": "abc"}) }}\nselect 1 as id\n'
+        )
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert result.refactored
+        assert 'tags="three"' in result.refactored_content
+        assert result.refactor_logs[0] == (
+            "Config key 'tags' was defined 3 times in the config() dictionary; "
+            'kept the last value ("three") and dropped the earlier ones ("one", "two"), '
+            "which is how dbt resolves a repeated key."
+        )
+
+    def test_repeated_dict_key_without_other_trigger_is_left_alone(self, schema_specs: SchemaSpecs):
+        """A duplicate alone is not a reason to rewrite the file, so nothing is reported."""
+        sql_content = '{{ config({"materialized": "table", "tags": "first", "tags": "second"}) }}\nselect 1 as id\n'
+
+        result = refactor_custom_configs_to_meta_sql(_sql(sql_content), _sql_cfg(schema_specs, "models"))
+
+        assert not result.refactored
+        assert result.refactored_content == sql_content
+        assert result.refactor_logs == []

--- a/tests/unit_tests/test_static_analysis.py
+++ b/tests/unit_tests/test_static_analysis.py
@@ -6,6 +6,7 @@ from ruamel.yaml.comments import CommentedMap
 from dbt_autofix.refactors.changesets.dbt_sql import refactor_static_analysis_sql
 from dbt_autofix.refactors.results import SQLContent, YMLContent
 from dbt_autofix.refactors.static_analysis import (
+    STATIC_ANALYSIS_DEPRECATION,
     changeset_normalize_static_analysis_yml,
     normalize_static_analysis_source,
     normalize_static_analysis_value,
@@ -152,3 +153,22 @@ def test_sql_config_already_valid_is_noop():
     content = SQLContent(original_str=sql, current_str=sql, current_file_path=Path("x.sql"))
     result = refactor_static_analysis_sql(content, None)
     assert result.refactored is False
+
+
+def test_sql_config_dict_repeated_key_keeps_last_value():
+    """Normalizing static_analysis collapses the dict, so a repeated key resolves as dbt does."""
+    sql = '{{ config({"materialized": "table", "tags": "first", "tags": "second", "static_analysis": True}) }}\nselect 1 as id\n'
+    content = SQLContent(original_str=sql, current_str=sql, current_file_path=Path("x.sql"))
+    result = refactor_static_analysis_sql(content, None)
+
+    assert result.refactored
+    assert 'tags="second"' in result.refactored_content
+    assert result.refactor_logs == [
+        "Config key 'tags' was defined 2 times in the config() dictionary; "
+        'kept the last value ("second") and dropped the earlier one ("first"), '
+        "which is how dbt resolves a repeated key.",
+        "Converted static_analysis=True to static_analysis='baseline' (static_analysis must be a Fusion enum value)",
+    ]
+    # The duplicate note carries no deprecation; the static_analysis conversion does
+    assert result.deprecation_refactors[0].deprecation is None
+    assert result.deprecation_refactors[1].deprecation == STATIC_ANALYSIS_DEPRECATION


### PR DESCRIPTION
Fixes https://github.com/dbt-labs/dbt-autofix/issues/434

## Description

When a `.sql` model's `config()` is written in dict-argument form, autofix collapses it into
keyword-argument form as part of other refactors (e.g. the `post-hook` → `post_hook` rename).
If the dict had a repeated key, autofix kept the **first** occurrence and silently dropped the
rest. Jinja and Python both resolve a repeated dict literal key to its **last** occurrence, so
autofix was changing a model's effective config while reporting only the unrelated rename.

For a repeated `tags` key this changes which tags a model carries, which changes node
selection. Found while investigating a spurious `dbt1310 ReplayDataMissing` conformance
divergence on dbt-labs/fs#11684 — the divergence was created by autofix rewriting the file,
not by Fusion.

This affects every rule that collapses dict form, not just the hook rename — reproduced via
`move_custom_configs_to_meta_sql` and `normalize_static_analysis_sql` too. A repeated key
alone still does not trigger a rewrite, so untouched files stay untouched.

Changes:

- Values are resolved through a forward cursor, so the *i*-th occurrence of a key binds to the
  *i*-th pair in the source and the last one wins. Values are still extracted as original
  source text, so Jinja expressions like `env_var('X')` and the author's formatting survive.
- Both key quoting styles are considered together (earliest match, not first pattern). Trying
  the patterns in order bound a key to a later, differently quoted occurrence and skipped the
  one in between, which fabricated a value that appeared nowhere in the source.
- A lookup miss re-scans the dictionary, so a mis-parsed earlier value degrades to binding the
  first occurrence rather than cascading fabricated values onto later keys.
- Collapsing a repeated key now emits its own log entry naming the key, the count, and the
  surviving value, distinct from whatever refactor triggered the rewrite.

Known limitations, unchanged by this PR and filed separately: a repeated key whose surviving
value is a nested dict literal still truncates, and `{"post_hook": ..., "post-hook": ...}`
(two distinct keys that collapse only because of the rename) still silently prefers the
hyphenated value.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Checklist

*   [x] Ran `uv run ruff check . --config pyproject.toml`
*   [x] Ran `uv run ruff format --config pyproject.toml`
*   [x] Ran `uv run ty check`
*   [x] If this is a bug fix:
    *   [x] Updated integration tests with bug repro
    *   [x] Linked to bug report ticket
*   [x] Added unit tests if needed
*   [x] Updated unit tests if needed
*   [x] Tests passed when run locally